### PR TITLE
fix: add Noto CJK and emoji fonts to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && \
     fonts-liberation \
     fonts-noto-cjk \
     fonts-noto-cjk-extra \
-    fonts-noto-color-emoji && \
+    fonts-noto-color-emoji \
     libpango-1.0-0 \
     libpangoft2-1.0-0 \
     python3-brotli \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,9 @@ RUN apt-get update && \
     dbus \
     fonts-dejavu \
     fonts-liberation \
+    fonts-noto-cjk \
+    fonts-noto-cjk-extra \
+    fonts-noto-color-emoji && \
     libpango-1.0-0 \
     libpangoft2-1.0-0 \
     python3-brotli \


### PR DESCRIPTION
Refs: #190

### Proposed changes

This pull request adds support for additional fonts in the Docker image to improve internationalization and emoji rendering.

Font support enhancements:

* Added `fonts-noto-cjk`, `fonts-noto-cjk-extra`, and `fonts-noto-color-emoji` to the list of installed packages in the `Dockerfile` to enable better rendering of CJK (Chinese, Japanese, Korean) characters and color emoji.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
