### PR TITLE
test: support custom metadata in PDF conversion

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -4,8 +4,8 @@ from pydantic import BaseModel, Field
 class VersionSchema(BaseModel):
     """Schema for response /version"""
 
-    python: str = Field(description="Python version")
-    weasyprint: str = Field(description="WeasyPrint version")
-    weasyprintService: str = Field(description="Service version")
-    timestamp: str = Field(description="Build timestamp")
-    chromium: str = Field(description="Chromium version")
+    python: str = Field(title="Python", description="Python version")
+    weasyprint: str = Field(title="WeasyPrint", description="WeasyPrint version")
+    weasyprintService: str = Field(title="WeasyPrint Service", description="Service version")
+    timestamp: str = Field(title="Build Timestamp", description="Build timestamp")
+    chromium: str = Field(title="Chromium", description="Chromium version")

--- a/app/static/openapi.json
+++ b/app/static/openapi.json
@@ -1,15 +1,18 @@
 {
   "openapi": "3.1.0",
   "info": {
-    "title": "FastAPI",
-    "version": "0.1.0"
+    "title": "WeasyPrint Service API",
+    "version": "1.0.0"
   },
   "paths": {
     "/version": {
       "get": {
-        "summary": "Version",
-        "description": "Get version information",
-        "operationId": "version_version_get",
+        "tags": [
+          "meta"
+        ],
+        "summary": "Service version information",
+        "description": "Returns versions of Python, WeasyPrint, the service itself, build timestamp, and Chromium.",
+        "operationId": "getVersion",
         "responses": {
           "200": {
             "description": "Successful Response",
@@ -26,9 +29,12 @@
     },
     "/convert/html": {
       "post": {
-        "summary": "Convert Html",
-        "description": "Convert HTML to PDF",
-        "operationId": "convert_html_convert_html_post",
+        "tags": [
+          "convert"
+        ],
+        "summary": "Convert HTML to PDF",
+        "description": "Accepts raw HTML in the request body and returns a generated PDF.",
+        "operationId": "convert_html_post",
         "parameters": [
           {
             "name": "encoding",
@@ -36,9 +42,11 @@
             "required": false,
             "schema": {
               "type": "string",
-              "default": "utf-8",
-              "title": "Encoding"
-            }
+              "title": "Encoding",
+              "description": "Text encoding used to decode the incoming HTML body (e.g., utf-8).",
+              "default": "utf-8"
+            },
+            "description": "Text encoding used to decode the incoming HTML body (e.g., utf-8)."
           },
           {
             "name": "media_type",
@@ -46,9 +54,11 @@
             "required": false,
             "schema": {
               "type": "string",
-              "default": "print",
-              "title": "Media Type"
-            }
+              "title": "CSS Media Type",
+              "description": "CSS media type to apply when rendering (e.g., 'print' or 'screen').",
+              "default": "print"
+            },
+            "description": "CSS media type to apply when rendering (e.g., 'print' or 'screen')."
           },
           {
             "name": "presentational_hints",
@@ -56,9 +66,11 @@
             "required": false,
             "schema": {
               "type": "boolean",
-              "default": false,
-              "title": "Presentational Hints"
-            }
+              "title": "Presentational Hints",
+              "description": "Honor presentational HTML attributes as CSS hints.",
+              "default": false
+            },
+            "description": "Honor presentational HTML attributes as CSS hints."
           },
           {
             "name": "base_url",
@@ -73,8 +85,10 @@
                   "type": "null"
                 }
               ],
-              "title": "Base Url"
-            }
+              "title": "Base URL",
+              "description": "Base URL used to resolve relative links (stylesheets, images)."
+            },
+            "description": "Base URL used to resolve relative links (stylesheets, images)."
           },
           {
             "name": "file_name",
@@ -82,9 +96,11 @@
             "required": false,
             "schema": {
               "type": "string",
-              "default": "converted-document.pdf",
-              "title": "File Name"
-            }
+              "title": "Output File Name",
+              "description": "Filename suggested in the Content-Disposition header.",
+              "default": "converted-document.pdf"
+            },
+            "description": "Filename suggested in the Content-Disposition header."
           },
           {
             "name": "pdf_variant",
@@ -99,8 +115,10 @@
                   "type": "null"
                 }
               ],
-              "title": "Pdf Variant"
-            }
+              "title": "PDF Variant",
+              "description": "PDF profile/variant passed to WeasyPrint (e.g., 'pdf/a-2b')."
+            },
+            "description": "PDF profile/variant passed to WeasyPrint (e.g., 'pdf/a-2b')."
           },
           {
             "name": "custom_metadata",
@@ -108,9 +126,11 @@
             "required": false,
             "schema": {
               "type": "boolean",
-              "default": false,
-              "title": "Custom Metadata"
-            }
+              "title": "Custom Metadata",
+              "description": "Include custom metadata in the generated PDF.",
+              "default": false
+            },
+            "description": "Include custom metadata in the generated PDF."
           }
         ],
         "responses": {
@@ -149,9 +169,12 @@
     },
     "/convert/html-with-attachments": {
       "post": {
-        "summary": "Convert Html With Attachments",
-        "description": "Convert HTML to PDF and embed provided files as PDF attachments.",
-        "operationId": "convert_html_with_attachments_convert_html_with_attachments_post",
+        "tags": [
+          "convert"
+        ],
+        "summary": "Convert HTML to PDF with attachments",
+        "description": "Accepts HTML as a form field and optional files to be embedded as PDF attachments.",
+        "operationId": "convert_html_with_attachments_post",
         "parameters": [
           {
             "name": "encoding",
@@ -159,9 +182,11 @@
             "required": false,
             "schema": {
               "type": "string",
-              "default": "utf-8",
-              "title": "Encoding"
-            }
+              "title": "Encoding",
+              "description": "Text encoding used to decode the incoming HTML body (e.g., utf-8).",
+              "default": "utf-8"
+            },
+            "description": "Text encoding used to decode the incoming HTML body (e.g., utf-8)."
           },
           {
             "name": "media_type",
@@ -169,9 +194,11 @@
             "required": false,
             "schema": {
               "type": "string",
-              "default": "print",
-              "title": "Media Type"
-            }
+              "title": "CSS Media Type",
+              "description": "CSS media type to apply when rendering (e.g., 'print' or 'screen').",
+              "default": "print"
+            },
+            "description": "CSS media type to apply when rendering (e.g., 'print' or 'screen')."
           },
           {
             "name": "presentational_hints",
@@ -179,9 +206,11 @@
             "required": false,
             "schema": {
               "type": "boolean",
-              "default": false,
-              "title": "Presentational Hints"
-            }
+              "title": "Presentational Hints",
+              "description": "Honor presentational HTML attributes as CSS hints.",
+              "default": false
+            },
+            "description": "Honor presentational HTML attributes as CSS hints."
           },
           {
             "name": "base_url",
@@ -196,8 +225,10 @@
                   "type": "null"
                 }
               ],
-              "title": "Base Url"
-            }
+              "title": "Base URL",
+              "description": "Base URL used to resolve relative links (stylesheets, images)."
+            },
+            "description": "Base URL used to resolve relative links (stylesheets, images)."
           },
           {
             "name": "file_name",
@@ -205,9 +236,11 @@
             "required": false,
             "schema": {
               "type": "string",
-              "default": "converted-document.pdf",
-              "title": "File Name"
-            }
+              "title": "Output File Name",
+              "description": "Filename suggested in the Content-Disposition header.",
+              "default": "converted-document.pdf"
+            },
+            "description": "Filename suggested in the Content-Disposition header."
           },
           {
             "name": "pdf_variant",
@@ -222,8 +255,10 @@
                   "type": "null"
                 }
               ],
-              "title": "Pdf Variant"
-            }
+              "title": "PDF Variant",
+              "description": "PDF profile/variant passed to WeasyPrint (e.g., 'pdf/a-2b')."
+            },
+            "description": "PDF profile/variant passed to WeasyPrint (e.g., 'pdf/a-2b')."
           },
           {
             "name": "custom_metadata",
@@ -231,9 +266,11 @@
             "required": false,
             "schema": {
               "type": "boolean",
-              "default": false,
-              "title": "Custom Metadata"
-            }
+              "title": "Custom Metadata",
+              "description": "Include custom metadata in the generated PDF.",
+              "default": false
+            },
+            "description": "Include custom metadata in the generated PDF."
           }
         ],
         "requestBody": {
@@ -241,7 +278,7 @@
           "content": {
             "multipart/form-data": {
               "schema": {
-                "$ref": "#/components/schemas/Body_convert_html_with_attachments_convert_html_with_attachments_post"
+                "$ref": "#/components/schemas/Body_convert_html_with_attachments_post"
               }
             }
           }
@@ -283,11 +320,12 @@
   },
   "components": {
     "schemas": {
-      "Body_convert_html_with_attachments_convert_html_with_attachments_post": {
+      "Body_convert_html_with_attachments_post": {
         "properties": {
           "html": {
             "type": "string",
-            "title": "Html"
+            "title": "HTML",
+            "description": "HTML content to render to PDF."
           },
           "files": {
             "anyOf": [
@@ -302,14 +340,15 @@
                 "type": "null"
               }
             ],
-            "title": "Files"
+            "title": "Attachments",
+            "description": "Files to embed as PDF attachments."
           }
         },
         "type": "object",
         "required": [
           "html"
         ],
-        "title": "Body_convert_html_with_attachments_convert_html_with_attachments_post"
+        "title": "Body_convert_html_with_attachments_post"
       },
       "HTTPValidationError": {
         "properties": {
@@ -366,17 +405,17 @@
           },
           "weasyprint": {
             "type": "string",
-            "title": "Weasyprint",
+            "title": "WeasyPrint",
             "description": "WeasyPrint version"
           },
           "weasyprintService": {
             "type": "string",
-            "title": "Weasyprintservice",
+            "title": "WeasyPrint Service",
             "description": "Service version"
           },
           "timestamp": {
             "type": "string",
-            "title": "Timestamp",
+            "title": "Build Timestamp",
             "description": "Build timestamp"
           },
           "chromium": {

--- a/app/static/openapi.json
+++ b/app/static/openapi.json
@@ -1,19 +1,18 @@
 {
-  "openapi": "3.0.3",
+  "openapi": "3.1.0",
   "info": {
-    "title": "WeasyPrint Service API",
-    "version": "1.0.0"
+    "title": "FastAPI",
+    "version": "0.1.0"
   },
   "paths": {
     "/version": {
       "get": {
-        "tags": [
-          "Service Info"
-        ],
-        "summary": "Get version info",
+        "summary": "Version",
+        "description": "Get version information",
+        "operationId": "version_version_get",
         "responses": {
           "200": {
-            "description": "Version data",
+            "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {
@@ -27,85 +26,256 @@
     },
     "/convert/html": {
       "post": {
-        "tags": [
-          "Conversion"
-        ],
-        "summary": "Convert HTML to PDF",
+        "summary": "Convert Html",
+        "description": "Convert HTML to PDF",
+        "operationId": "convert_html_convert_html_post",
         "parameters": [
           {
-            "in": "query",
             "name": "encoding",
+            "in": "query",
+            "required": false,
             "schema": {
               "type": "string",
-              "default": "utf-8"
+              "default": "utf-8",
+              "title": "Encoding"
             }
           },
           {
-            "in": "query",
             "name": "media_type",
+            "in": "query",
+            "required": false,
             "schema": {
               "type": "string",
-              "default": "print"
+              "default": "print",
+              "title": "Media Type"
             }
           },
           {
-            "in": "query",
-            "name": "file_name",
-            "schema": {
-              "type": "string",
-              "default": "converted-document.pdf"
-            }
-          },
-          {
-            "in": "query",
-            "name": "pdf_variant",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
             "name": "presentational_hints",
+            "in": "query",
+            "required": false,
             "schema": {
               "type": "boolean",
-              "default": false
+              "default": false,
+              "title": "Presentational Hints"
             }
           },
           {
-            "in": "query",
             "name": "base_url",
+            "in": "query",
+            "required": false,
             "schema": {
-              "type": "string"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Base Url"
+            }
+          },
+          {
+            "name": "file_name",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "converted-document.pdf",
+              "title": "File Name"
+            }
+          },
+          {
+            "name": "pdf_variant",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Pdf Variant"
+            }
+          },
+          {
+            "name": "custom_metadata",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Custom Metadata"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "text/plain": {}
+            },
+            "description": "Invalid Input"
+          },
+          "500": {
+            "content": {
+              "text/plain": {}
+            },
+            "description": "Internal PDF Conversion Error"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/convert/html-with-attachments": {
+      "post": {
+        "summary": "Convert Html With Attachments",
+        "description": "Convert HTML to PDF and embed provided files as PDF attachments.",
+        "operationId": "convert_html_with_attachments_convert_html_with_attachments_post",
+        "parameters": [
+          {
+            "name": "encoding",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "utf-8",
+              "title": "Encoding"
+            }
+          },
+          {
+            "name": "media_type",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "print",
+              "title": "Media Type"
+            }
+          },
+          {
+            "name": "presentational_hints",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Presentational Hints"
+            }
+          },
+          {
+            "name": "base_url",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Base Url"
+            }
+          },
+          {
+            "name": "file_name",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "converted-document.pdf",
+              "title": "File Name"
+            }
+          },
+          {
+            "name": "pdf_variant",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Pdf Variant"
+            }
+          },
+          {
+            "name": "custom_metadata",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Custom Metadata"
             }
           }
         ],
         "requestBody": {
           "required": true,
           "content": {
-            "text/html": {
+            "multipart/form-data": {
               "schema": {
-                "type": "string"
+                "$ref": "#/components/schemas/Body_convert_html_with_attachments_convert_html_with_attachments_post"
               }
             }
           }
         },
         "responses": {
           "200": {
-            "description": "PDF successfully generated",
+            "description": "Successful Response",
             "content": {
-              "application/pdf": {
-                "schema": {
-                  "type": "string",
-                  "format": "binary"
-                }
+              "application/json": {
+                "schema": {}
               }
             }
           },
           "400": {
-            "description": "Invalid input"
+            "content": {
+              "text/plain": {}
+            },
+            "description": "Invalid Input"
           },
           "500": {
-            "description": "Internal server error"
+            "content": {
+              "text/plain": {}
+            },
+            "description": "Internal PDF Conversion Error"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
           }
         }
       }
@@ -113,34 +283,118 @@
   },
   "components": {
     "schemas": {
-      "VersionSchema": {
+      "Body_convert_html_with_attachments_convert_html_with_attachments_post": {
+        "properties": {
+          "html": {
+            "type": "string",
+            "title": "Html"
+          },
+          "files": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string",
+                  "format": "binary"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Files"
+          }
+        },
         "type": "object",
+        "required": [
+          "html"
+        ],
+        "title": "Body_convert_html_with_attachments_convert_html_with_attachments_post"
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError"
+      },
+      "VersionSchema": {
         "properties": {
           "python": {
             "type": "string",
+            "title": "Python",
             "description": "Python version"
           },
           "weasyprint": {
             "type": "string",
+            "title": "Weasyprint",
             "description": "WeasyPrint version"
           },
           "weasyprintService": {
             "type": "string",
+            "title": "Weasyprintservice",
             "description": "Service version"
           },
           "timestamp": {
             "type": "string",
+            "title": "Timestamp",
             "description": "Build timestamp"
           },
           "chromium": {
             "type": "string",
+            "title": "Chromium",
             "description": "Chromium version"
           }
         },
+        "type": "object",
         "required": [
           "python",
-          "weasyprint"
-        ]
+          "weasyprint",
+          "weasyprintService",
+          "timestamp",
+          "chromium"
+        ],
+        "title": "VersionSchema",
+        "description": "Schema for response /version"
       }
     }
   }

--- a/tests/test-data/html-with-custom-metadata.html
+++ b/tests/test-data/html-with-custom-metadata.html
@@ -1,0 +1,22 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE html PUBLIC '-//W3C//DTD XHTML 1.0 Strict//EN' 'http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd'>
+<html lang='en' xml:lang='en' xmlns='http://www.w3.org/1999/xhtml'>
+<head>
+    <title>test with custom metadata</title>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type'/>
+    <base href='http://203b8479fbd1' />
+    <meta name="author" content="Jane Doe">
+    <meta name="author" content="John Doe">
+    <meta name="generator" content="HTML generator">
+    <meta name="keywords" content="HTML, CSS, PDF">
+    <meta name="keywords" content="custom, fileds, metadata">
+</head>
+<body>
+<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+<p>Pellentesque nec rhoncus neque, sed vestibulum nibh. Nam sodales eget leo eu egestas.</p>
+<p>Curabitur malesuada vel eros in maximus.</p>
+<p>Mauris ut libero feugiat, gravida ipsum id, sodales nibh.</p>
+<p>In malesuada porta eros, et auctor risus.</p>
+<p>Nunc ipsum quam, sodales sed nisl sit amet, viverra facilisis neque.</p>
+</body>
+</html>

--- a/tests/test-data/html-with-custom-metadata.html
+++ b/tests/test-data/html-with-custom-metadata.html
@@ -9,7 +9,7 @@
     <meta name="author" content="John Doe">
     <meta name="generator" content="HTML generator">
     <meta name="keywords" content="HTML, CSS, PDF">
-    <meta name="keywords" content="custom, fileds, metadata">
+    <meta name="keywords" content="custom, fields, metadata">
 </head>
 <body>
 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -313,7 +313,7 @@ def test_convert_html_with_custom_metadata(test_parameters: TestParameters) -> N
 
     assert title == "test with custom metadata"
     assert "Jane Doe, John Doe" in author
-    assert "HTML, CSS, PDF, custom, fileds, metadata" in keywords
+    assert "HTML, CSS, PDF, custom, fields, metadata" in keywords
     assert creator == "HTML generator"
     assert producer.startswith("WeasyPrint")
 

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -279,6 +279,45 @@ def test_supported_pdf_variants(variant: str, is_supported: bool, test_parameter
         assert response.status_code == 400
 
 
+def test_convert_html_with_custom_metadata(test_parameters: TestParameters) -> None:
+    html = __load_test_html("tests/test-data/html-with-custom-metadata.html")
+    # Enable inclusion of custom metadata in the generated PDF
+    response = __call_convert_html(
+        base_url=test_parameters.base_url,
+        request_session=test_parameters.request_session,
+        data=html,
+        print_error=True,
+        parameters="custom_metadata=true",
+    )
+
+    assert response.status_code == 200
+    flush_tmp_file("test_convert_html_with_custom_metadata.pdf", response.content, test_parameters.flush_tmp_file_enabled)
+
+    stream = io.BytesIO(response.content)
+    pdf_reader = PyPDF.PdfReader(stream)
+
+    # Basic PDF validation
+    assert len(pdf_reader.pages) == 1
+    page_text = pdf_reader.pages[0].extract_text()
+    assert "Lorem ipsum dolor sit amet, consectetur adipiscing elit." in page_text
+
+    # Validate metadata populated from HTML meta tags
+    metadata = pdf_reader.metadata
+    assert metadata is not None, "Expected metadata to be present when custom_metadata=true"
+
+    title: str = metadata.get("/Title")
+    author: str = metadata.get("/Author")
+    keywords: str = metadata.get("/Keywords")
+    creator: str = metadata.get("/Creator")
+    producer: str = metadata.get("/Producer")
+
+    assert title == "test with custom metadata"
+    assert "Jane Doe, John Doe" in author
+    assert "HTML, CSS, PDF, custom, fileds, metadata" in keywords
+    assert creator == "HTML generator"
+    assert producer.startswith("WeasyPrint")
+
+
 def __get_pdf_variant_from_metadata(pdf_reader: PyPDF.PdfReader) -> str:
     if pdf_reader.xmp_metadata and pdf_reader.xmp_metadata.rdf_root:
         for rdf_node in pdf_reader.xmp_metadata.rdf_root.childNodes:


### PR DESCRIPTION
Refs: #193

### Proposed changes

This pull request adds a new test to validate that custom metadata from HTML `<meta>` tags is correctly included in the generated PDF when the `custom_metadata=true` parameter is used.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
