### PR TITLE
feat: Add environment variables to configure form parsing limits (`FORM_MAX_FIELDS`, `FORM_MAX_FILES`, `FORM_MAX_PART_SIZE`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,46 @@ docker-compose up -d
 
 The Docker Compose configuration includes the `init: true` parameter which enables proper process management for the container.
 
+### Multipart form limits (environment variables)
+
+The endpoint /convert/html-with-attachments parses multipart/form-data and supports configuring Starlette's form parsing limits via environment variables:
+
+- FORM_MAX_FIELDS: Maximum number of non-file form fields to accept. Default: 1000.
+- FORM_MAX_FILES: Maximum number of file parts to accept. Default: 1000.
+- FORM_MAX_PART_SIZE: Maximum allowed size in bytes for any single part (file or field). Default: 10485760 (10 MiB).
+
+Notes:
+- Values are parsed as integers. Invalid or negative values fall back to the defaults (negative values are clamped to 0 internally).
+- These limits only affect the /convert/html-with-attachments endpoint. The endpoint requires Content-Type: multipart/form-data and will return 400 Bad Request otherwise.
+
+Examples:
+
+Docker run:
+```bash
+docker run --detach \
+  --init \
+  --publish 9080:9080 \
+  --name weasyprint-service \
+  -e FORM_MAX_FIELDS=2000 \
+  -e FORM_MAX_FILES=2000 \
+  -e FORM_MAX_PART_SIZE=20971520 \
+  ghcr.io/schweizerischebundesbahnen/weasyprint-service:latest
+```
+
+docker-compose.yml:
+```yaml
+services:
+  weasyprint:
+    image: ghcr.io/schweizerischebundesbahnen/weasyprint-service:latest
+    init: true
+    environment:
+      FORM_MAX_FIELDS: 2000
+      FORM_MAX_FILES: 2000
+      FORM_MAX_PART_SIZE: 20971520
+    ports:
+      - "9080:9080"
+```
+
 ## Development
 
 ### Building the Docker Image

--- a/app/attachment_manager.py
+++ b/app/attachment_manager.py
@@ -10,7 +10,7 @@ from bs4 import BeautifulSoup, Tag
 if TYPE_CHECKING:  # imports used only for type hints
     from collections.abc import Sequence
 
-    from fastapi import UploadFile
+    from starlette.datastructures import UploadFile
 
 
 class AttachmentManager:

--- a/app/form_parser.py
+++ b/app/form_parser.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+from starlette.datastructures import FormData, UploadFile
+
+if TYPE_CHECKING:  # ruff: noqa: TCH004
+    from fastapi import Request
+
+
+class FormParser:
+    """
+    Helper class to parse multipart form data with configurable limits
+    from environment variables.
+    """
+
+    def __init__(
+        self,
+        max_files: int | None = None,
+        max_fields: int | None = None,
+        max_part_size: int | None = None,
+    ) -> None:
+        self.max_files = max_files or self._get_int_env("FORM_MAX_FILES", 1000)
+        self.max_fields = max_fields or self._get_int_env("FORM_MAX_FIELDS", 1000)
+        self.max_part_size = max_part_size or self._get_int_env("FORM_MAX_PART_SIZE", 10 * 1024 * 1024)
+
+    @staticmethod
+    def _get_int_env(name: str, default: int) -> int:
+        """Read positive int from env var or fall back to default."""
+        try:
+            value = int(os.environ.get(name, str(default)))
+            return max(0, value)
+        except (ValueError, TypeError):
+            return default
+
+    async def parse(self, request: Request) -> FormData:
+        """
+        Parse the form with configured limits.
+        """
+        return await request.form(
+            max_files=self.max_files,
+            max_fields=self.max_fields,
+            max_part_size=self.max_part_size,
+        )
+
+    @staticmethod
+    def html_from_form(form: FormData, encoding: str = "utf-8") -> str:
+        """
+        Extract the "html" field from the form and decode if needed.
+        """
+        html_field = form.get("html")
+        if html_field is None:
+            raise AssertionError(400, "Missing html form field")
+        return html_field.decode(encoding) if isinstance(html_field, bytes) else str(html_field)
+
+    @staticmethod
+    def collect_files_from_form(form: FormData) -> list[UploadFile]:
+        """
+        Collect files from the "files" field.
+        """
+        files: list[UploadFile] = []
+        for v in form.getlist("files"):
+            if isinstance(v, UploadFile):
+                if not v.filename:
+                    v.filename = "attachment.bin"
+                files.append(v)
+        return files

--- a/app/weasyprint_controller.py
+++ b/app/weasyprint_controller.py
@@ -10,7 +10,7 @@ from urllib.parse import unquote
 
 import uvicorn
 import weasyprint  # type: ignore
-from fastapi import Depends, FastAPI, Query, Request, Response
+from fastapi import Depends, FastAPI, HTTPException, Query, Request, Response
 from pydantic import BaseModel
 from starlette.datastructures import FormData, UploadFile
 
@@ -33,7 +33,7 @@ def _get_int_env(name: str, default: int) -> int:
     try:
         value = int(os.environ.get(name, str(default)))
         return max(0, value)
-    except Exception:
+    except (ValueError, TypeError):
         return default
 
 
@@ -51,7 +51,7 @@ async def _parse_form_with_limits(request: Request) -> FormData:
 def _html_from_form(form: FormData, encoding: str) -> str:
     html_field = form.get("html")
     if html_field is None:
-        raise AssertionError("Missing 'html' form field")
+        raise HTTPException(400, "Missing html form field")
     return html_field.decode(encoding) if isinstance(html_field, bytes) else str(html_field)
 
 

--- a/app/weasyprint_service_application.py
+++ b/app/weasyprint_service_application.py
@@ -4,6 +4,8 @@ import os
 from datetime import datetime
 from pathlib import Path
 
+import uvicorn
+
 from app import weasyprint_controller  # type: ignore
 
 
@@ -68,6 +70,10 @@ def setup_logging() -> Path:
     return log_file  # Return log file path for testing
 
 
+def start_server(port: int) -> None:
+    uvicorn.run(app=weasyprint_controller.app, host="", port=port)
+
+
 def main() -> None:
     """
     Main entry point for the WeasyPrint service.
@@ -82,7 +88,7 @@ def main() -> None:
     setup_logging()
     logging.info("Weasyprint service listening port: " + str(args.port))
 
-    weasyprint_controller.start_server(args.port)
+    start_server(args.port)
 
 
 if __name__ == "__main__":

--- a/tests/test_form_parser.py
+++ b/tests/test_form_parser.py
@@ -1,0 +1,168 @@
+import io
+from typing import Any
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+from starlette.datastructures import FormData, UploadFile
+
+from app.form_parser import FormParser
+
+
+# ---------- Unit: ENV and constructor ----------
+
+def test_init_defaults_and_env(monkeypatch: pytest.MonkeyPatch):
+    # Environment variables should be respected if provided
+    monkeypatch.setenv("FORM_MAX_FILES", "11")
+    monkeypatch.setenv("FORM_MAX_FIELDS", "22")
+    monkeypatch.setenv("FORM_MAX_PART_SIZE", "333")
+
+    parser = FormParser()
+
+    assert parser.max_files == 11
+    assert parser.max_fields == 22
+    assert parser.max_part_size == 333
+
+
+def test_init_constructor_overrides_env(monkeypatch: pytest.MonkeyPatch):
+    # Values passed to the constructor should override environment variables
+    monkeypatch.setenv("FORM_MAX_FILES", "1000")
+    monkeypatch.setenv("FORM_MAX_FIELDS", "1000")
+    monkeypatch.setenv("FORM_MAX_PART_SIZE", "999999")
+
+    parser = FormParser(max_files=5, max_fields=6, max_part_size=7)
+
+    assert parser.max_files == 5
+    assert parser.max_fields == 6
+    assert parser.max_part_size == 7
+
+
+def test_init_invalid_env(monkeypatch: pytest.MonkeyPatch):
+    # Invalid environment variables should fall back to defaults
+    monkeypatch.setenv("FORM_MAX_FILES", "not-an-int")
+    monkeypatch.setenv("FORM_MAX_FIELDS", "")
+    monkeypatch.setenv("FORM_MAX_PART_SIZE", "None")
+
+    parser = FormParser()
+
+    assert parser.max_files == 1000
+    assert parser.max_fields == 1000
+    assert parser.max_part_size == 10 * 1024 * 1024
+
+
+# ---------- Unit: html_from_form ----------
+
+def test_html_from_form_accepts_str():
+    # String input should be returned as-is
+    form = FormData([("html", "Hello <b>world</b>")])
+    got = FormParser.html_from_form(form)
+    assert got == "Hello <b>world</b>"
+
+
+def test_html_from_form_accepts_bytes_utf8():
+    # Bytes input should be decoded using UTF-8 by default
+    form = FormData([("html", "Hello".encode("utf-8"))])
+    got = FormParser.html_from_form(form)
+    assert got == "Hello"
+
+
+def test_html_from_form_missing_raises():
+    # Missing "html" field should raise AssertionError
+    form = FormData([])
+    with pytest.raises(AssertionError) as ei:
+        FormParser.html_from_form(form)
+    assert ei.value.args == (400, "Missing html form field")
+
+
+# ---------- Unit: collect_files_from_form ----------
+
+def _uf(name: str | None, data: bytes = b"x") -> UploadFile:
+    # Helper to construct UploadFile with given name and content
+    return UploadFile(
+        filename=name,
+        file=io.BytesIO(data),
+        headers=None,
+    )
+
+def test_collect_files_dedup_by_basename_and_default_name():
+    form = FormData([
+        ("files", _uf("A.txt", b"1")),
+        ("files", _uf("A.txt", b"2")),
+        ("files", _uf("B.txt", b"3")),
+        ("files", _uf(None, b"4")), # -> attachment.bin
+        ("files", _uf("B.txt", b"5")),
+        ("files", _uf(None, b"6")),  # -> attachment.bin
+    ])
+
+    files = FormParser.collect_files_from_form(form)
+    names = [f.filename for f in files]
+
+    assert names == ["A.txt", "A.txt", "B.txt", "attachment.bin", "B.txt", "attachment.bin"]
+
+
+# ---------- Integration: FastAPI + parse() ----------
+
+def build_app(parser: FormParser) -> FastAPI:
+    app = FastAPI()
+
+    @app.post("/upload")
+    async def upload(request: Request) -> dict[str, Any]:
+        form = await parser.parse(request)
+        html = FormParser.html_from_form(form)
+        files = FormParser.collect_files_from_form(form)
+        return {
+            "html": html,
+            "file_names": [f.filename for f in files],
+            "limits": {
+                "max_files": parser.max_files,
+                "max_fields": parser.max_fields,
+                "max_part_size": parser.max_part_size,
+            },
+        }
+
+    return app
+
+
+def test_parse_integration_with_fastapi(monkeypatch: pytest.MonkeyPatch):
+    # Integration test with real multipart form parsing
+    monkeypatch.setenv("FORM_MAX_FILES", "3")
+    monkeypatch.setenv("FORM_MAX_FIELDS", "10")
+    monkeypatch.setenv("FORM_MAX_PART_SIZE", "1048576")  # 1 MiB
+
+    parser = FormParser()
+    app = build_app(parser)
+    client = TestClient(app)
+
+    files = [
+        ("files", ("a.txt", b"A")),
+        ("files", ("b.txt", b"B1")),
+        ("files", ("b.txt", b"B2")),
+    ]
+    resp = client.post("/upload", data={"html": "hi"}, files=files)
+    assert resp.status_code == 200, resp.text
+
+    payload = resp.json()
+    assert payload["html"] == "hi"
+    assert payload["file_names"] == ["a.txt", "b.txt", "b.txt"]
+    assert payload["limits"] == {
+        "max_files": 3,
+        "max_fields": 10,
+        "max_part_size": 1048576,
+    }
+
+
+def test_parse_integration_html_bytes():
+    # Integration test with bytes in the "html" field
+    parser = FormParser()
+    app = build_app(parser)
+    client = TestClient(app)
+
+    resp = client.post(
+        "/upload",
+        data={"html": "Hello".encode("utf-8")},
+        files=[("files", ("x.bin", b"\x00\x01"))],
+    )
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["html"] == "Hello"
+    assert payload["file_names"] == ["x.bin"]

--- a/tests/test_weasyprint_controller.py
+++ b/tests/test_weasyprint_controller.py
@@ -51,8 +51,8 @@ def test_convert_html_with_attachments():
         result = test_client.post(
             "/convert/html-with-attachments",
         )
-        # Missing required form field 'html' should return 422 Unprocessable Entity
-        assert result.status_code == 422
+        # Missing required form field 'html' should return 400 Bad Request
+        assert result.status_code == 400
 
 
 def test_convert_html_with_attachments_files():

--- a/tests/test_weasyprint_service_application.py
+++ b/tests/test_weasyprint_service_application.py
@@ -19,7 +19,7 @@ def test_main_runs(monkeypatch, tmp_path):
     def fake_start_server(port):
         logger.info(f"Fake server started on port {port}")
 
-    monkeypatch.setattr(weasyprint_service_application.weasyprint_controller, "start_server", fake_start_server)
+    monkeypatch.setattr(weasyprint_service_application, "start_server", fake_start_server)
 
     # Run main and verify
     weasyprint_service_application.main()


### PR DESCRIPTION
### Proposed changes

Added support for configuring multipart form parsing limits (`FORM_MAX_FIELDS`, `FORM_MAX_FILES`, `FORM_MAX_PART_SIZE`) via environment variables for the `/convert/html-with-attachments` endpoint. These control the maximum number of fields, files, and the size of each part, with sensible defaults and validation.
Updated the `README.md` to document the new environment variables, their defaults, usage notes, and provided Docker usage examples.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
