### PR TITLE
fix: use explicit None check when reading sticky-note fields

### DIFF
--- a/app/notes_processor.py
+++ b/app/notes_processor.py
@@ -86,10 +86,10 @@ class NotesProcessor:
         text_tag = node.find("span", class_="sticky-note-text", recursive=False)
         title_tag = node.find("span", class_="sticky-note-title", recursive=False)
 
-        time = time_tag.get_text(strip=True) if time_tag else ""
-        username = username_tag.get_text(strip=True) if username_tag else ""
-        text = text_tag.get_text(strip=True) if text_tag else ""
-        title = title_tag.get_text(strip=True) if title_tag else ""
+        time = time_tag.get_text(strip=True) if time_tag is not None else ""
+        username = username_tag.get_text(strip=True) if username_tag is not None else ""
+        text = text_tag.get_text(strip=True) if text_tag is not None else ""
+        title = title_tag.get_text(strip=True) if title_tag is not None else ""
 
         # Find direct child notes (replies)
         replies: list[Note] = []


### PR DESCRIPTION
### Proposed changes

BeautifulSoup find() returns Tag or None. The truthiness guard (if tag) is not recognized by SonarCloud rule python:S8904 as an existence check, which flagged four CRITICAL reliability bugs and failed the quality gate on main. Switch to 'is not None', which is both the precise check for a missing element and the guard the rule recognizes.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
