### PR TITLE
chore: mark where repository-specific ignores go

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,10 @@ ignore = [
     "ANN401",  # Any is correct at JSON and **kwargs boundaries
     "FBT001",  # a boolean query parameter is part of the HTTP API
     "FBT002",  # same, with a default
+
+    # Repository-specific entries belong below this line, each with a reason, so
+    # the next sync of the shared block above can tell the two apart. Without the
+    # line a local entry looks shared and the sync deletes it silently.
 ]
 
 [tool.ruff.lint.mccabe]
@@ -133,7 +137,8 @@ max-args = 10
 # A repository-wide ignore does NOT go here. This is still
 # [tool.ruff.lint.per-file-ignores], so a bare ignore = ["RULE"] parses as a
 # glob named "ignore" that matches no file: it is accepted, it silences
-# nothing, and ruff says nothing. Add such a rule to the ignore list above.
+# nothing, and ruff says nothing. Add such a rule below the marker inside the
+# ignore list above.
 
 "tests/test_logging.py" = [
     "LOG015",  # this module tests the root logger that setup_logging configures


### PR DESCRIPTION
Follows the shared standard change in https://github.com/SchweizerischeBundesbahnen/open-source-polarion-python-repo-template/pull/133.

`[tool.ruff.lint.per-file-ignores]` already carries a marker separating the shared
block from repository-specific globs. The `ignore` list did not, yet its header
declares it the shared standard for all repositories.

So a local entry added there sits between two shared ones and looks shared. When
the block is next re-synced from the template, whoever does it cannot tell the
line was local, and the reviewers of that sync see a plain deletion with no
reason attached. The rule then starts firing on code that PR never touched.

This adds the marker and points the per-file-ignores note at it, so both halves
of the file follow one convention.

Comment-only. Verified with the pinned ruff: clean.