### PR TITLE
chore: keep the reason out of the noqa directive

### DIFF
--- a/app/chromium_manager.py
+++ b/app/chromium_manager.py
@@ -580,7 +580,8 @@ class ChromiumManager:
                 last_error = TimeoutError(f"Conversion timed out after {self.conversion_timeout} seconds")
                 self.log.error("SVG conversion timed out (attempt %d/%d): %d seconds", attempt + 1, self.max_conversion_retries, self.conversion_timeout)
                 await self._handle_conversion_retry(attempt, last_error, "timeout")
-            except Exception as e:  # noqa: BLE001 - any conversion failure feeds the retry loop
+            # Any conversion failure feeds the retry loop.
+            except Exception as e:  # noqa: BLE001
                 last_error = e
                 self.log.warning(
                     "SVG conversion failed (attempt %d/%d): %s. Attempting to restart Chromium...",
@@ -617,7 +618,8 @@ class ChromiumManager:
         try:
             await self.restart()
             self.log.info("Chromium restarted successfully after %s", error_type)
-        except Exception as restart_error:  # noqa: BLE001 - a failed restart is re-raised as RuntimeError
+        # A failed restart is re-raised as RuntimeError.
+        except Exception as restart_error:  # noqa: BLE001
             self.log.error("Failed to restart Chromium: %s", restart_error)
             raise RuntimeError(f"Chromium restart failed after {error_type}: {restart_error}") from error
 
@@ -828,7 +830,8 @@ class ChromiumManager:
                             await self.restart()
                             consecutive_failures = 0
                             self.log.info("Chromium restarted successfully after health check failure")
-                        except Exception as e:  # noqa: BLE001 - the health monitor keeps running after a failed restart
+                        # The health monitor keeps running after a failed restart.
+                        except Exception as e:  # noqa: BLE001
                             self.log.error("Failed to restart Chromium after health check failure: %s", e)
                             # Continue monitoring even if restart fails
 

--- a/app/notes_processor.py
+++ b/app/notes_processor.py
@@ -264,7 +264,8 @@ class NotesProcessor:
             # Note: Using private method _add_object() as pypdf 6.1.1 doesn't provide
             # a public API for adding custom XObject streams. This is the standard
             # approach for advanced PDF manipulation with pypdf.
-            return writer._add_object(xobject)  # type: ignore[attr-defined]  # noqa: SLF001 - pypdf exposes no public API for this
+            # Pypdf exposes no public API for this.
+            return writer._add_object(xobject)  # type: ignore[attr-defined]  # noqa: SLF001
 
         except Exception as e:
             logger.exception("Failed to embed PNG icon from %s: %s", png_path, e)
@@ -305,7 +306,8 @@ class NotesProcessor:
         # Add the appearance stream to the PDF
         # Note: Using private method _add_object() as pypdf 6.1.1 doesn't provide
         # a public API for adding custom appearance streams.
-        appearance_ref = writer._add_object(appearance_stream)  # type: ignore[attr-defined]  # noqa: SLF001 - pypdf exposes no public API for this
+        # Pypdf exposes no public API for this.
+        appearance_ref = writer._add_object(appearance_stream)  # type: ignore[attr-defined]  # noqa: SLF001
 
         # Create the appearance dictionary
         appearance_dict = DictionaryObject()

--- a/app/sanitization.py
+++ b/app/sanitization.py
@@ -58,7 +58,8 @@ def sanitize_url_for_logging(url: str | None) -> str:
             safe_url += f":{parsed.port}"
         safe_url += parsed.path or "/"
         return sanitize_for_logging(safe_url, max_length=200)
-    except Exception:  # noqa: BLE001 - sanitization must never fail, fall back to the generic path
+    # Sanitization must never fail, fall back to the generic path.
+    except Exception:  # noqa: BLE001
         # Fallback to generic sanitization if URL parsing fails
         return sanitize_for_logging(url, max_length=200)
 
@@ -113,5 +114,6 @@ def sanitize_path_for_logging(path: str | None, show_basename_only: bool = True)
         except ValueError, OSError:
             # Path is not in temp directory - return sanitized full path
             return sanitize_for_logging(str(path), max_length=200)
-    except Exception:  # noqa: BLE001 - same, for a path
+    # Same, for a path.
+    except Exception:  # noqa: BLE001
         return sanitize_for_logging(str(path), max_length=200)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -4,10 +4,12 @@ from pydantic import BaseModel, Field
 class VersionSchema(BaseModel):
     """Schema for response /version"""
 
-    apiVersion: int = Field(title="API Version", description="API version for compatibility checking with pdf-exporter")  # noqa: N815 - this is the JSON field name pdf-exporter reads
+    # This is the JSON field name pdf-exporter reads.
+    apiVersion: int = Field(title="API Version", description="API version for compatibility checking with pdf-exporter")  # noqa: N815
     python: str = Field(title="Python", description="Python version")
     weasyprint: str = Field(title="WeasyPrint", description="WeasyPrint version")
-    weasyprintService: str | None = Field(title="WeasyPrint Service", description="Service version")  # noqa: N815 - this is the JSON field name pdf-exporter reads
+    # This is the JSON field name pdf-exporter reads.
+    weasyprintService: str | None = Field(title="WeasyPrint Service", description="Service version")  # noqa: N815
     timestamp: str | None = Field(title="Build Timestamp", description="Build timestamp")
     chromium: str | None = Field(title="Chromium", description="Chromium version")
 

--- a/app/svg_processor.py
+++ b/app/svg_processor.py
@@ -18,7 +18,9 @@ import xml.etree.ElementTree as ET
 from typing import TYPE_CHECKING
 
 from bs4 import BeautifulSoup, Tag
-from defusedxml import ElementTree as det  # noqa: N813 - defusedxml exposes ElementTree as a module
+
+# Defusedxml exposes ElementTree as a module.
+from defusedxml import ElementTree as det  # noqa: N813
 
 if TYPE_CHECKING:  # used only for type hints
     from xml.etree.ElementTree import Element
@@ -155,7 +157,8 @@ class SvgProcessor:
             if style_parts:
                 node["style"] = "; ".join(style_parts)
 
-        except Exception as e:  # noqa: BLE001 - applying dimensions is best effort
+        # Applying dimensions is best effort.
+        except Exception as e:  # noqa: BLE001
             # Log at debug level to avoid noise but prevent silent pass
             logging.getLogger(__name__).debug("Failed to apply img dimensions from SVG: %s", e)
 
@@ -190,7 +193,8 @@ class SvgProcessor:
 
             possible_svg_content = decoded_content.decode("utf-8")
             return self.svg_from_string(possible_svg_content)
-        except Exception as e:  # noqa: BLE001 - any decode failure means this is not SVG
+        # Any decode failure means this is not SVG.
+        except Exception as e:  # noqa: BLE001
             self.log.error("Failed to decode base64 content: %s", e)
             return None
 
@@ -301,7 +305,8 @@ class SvgProcessor:
                 return None, None
             vb_width = float(parts[2])
             vb_height = float(parts[3])
-        except Exception:  # noqa: BLE001 - any parse failure means the dimensions are unknown
+        # Any parse failure means the dimensions are unknown.
+        except Exception:  # noqa: BLE001
             return None, None
         else:
             return vb_width, vb_height
@@ -353,7 +358,8 @@ class SvgProcessor:
     def convert_to_px(self, value: str | None, unit: str | None) -> int | None:
         try:
             if value is None:
-                raise ValueError  # noqa: TRY301 - the try converts, this guard rejects a missing value
+                # The try converts, this guard rejects a missing value.
+                raise ValueError  # noqa: TRY301
             value_f64 = float(value)
 
             if unit in self.SPECIAL_UNITS:

--- a/app/vsdx_processor.py
+++ b/app/vsdx_processor.py
@@ -106,7 +106,8 @@ class VsdxProcessor:
                 self.log.debug("Successfully converted VSDX to PNG")
             except VsdxConversionError as e:
                 self.log.warning("VSDX conversion failed, keeping original: %s", e)
-            except Exception as e:  # noqa: BLE001 - a conversion failure keeps the original attachment
+            # A conversion failure keeps the original attachment.
+            except Exception as e:  # noqa: BLE001
                 self.log.error("Unexpected error converting VSDX: %s", e)
 
         if converted_count > 0:
@@ -211,7 +212,8 @@ class VsdxProcessor:
 
             if not vsdx_content.startswith(b"PK"):
                 msg = f"VSDX missing ZIP header: {vsdx_content[:10]!r}"
-                raise VsdxCorruptedError(msg)  # noqa: TRY301 - the try wraps the decode, not this guard
+                # The try wraps the decode, not this guard.
+                raise VsdxCorruptedError(msg)  # noqa: TRY301
 
             temp_dir = tempfile.mkdtemp()
             temp_path = Path(temp_dir)
@@ -236,10 +238,12 @@ class VsdxProcessor:
         else:
             return png_content
         finally:
-            if temp_dir and Path(temp_dir).exists():  # noqa: ASYNC240 - a local stat costs far less than a thread hop
+            # A local stat costs far less than a thread hop.
+            if temp_dir and Path(temp_dir).exists():  # noqa: ASYNC240
                 try:
                     shutil.rmtree(temp_dir)
-                except Exception as e:  # noqa: BLE001 - temp directory cleanup is best effort
+                # Temp directory cleanup is best effort.
+                except Exception as e:  # noqa: BLE001
                     self.log.warning("Failed to cleanup temp directory %s: %s", temp_dir, e)
 
     # ---------------- Generic helpers ----------------

--- a/app/weasyprint_controller.py
+++ b/app/weasyprint_controller.py
@@ -397,7 +397,8 @@ async def convert_html(
         output_pdf = await __process_html_to_pdf(html, render, output, chromium_manager)
         response = await __create_response(output, output_pdf)
         __record_conversion_metrics(chromium_manager, start_time, success=True)
-    except Exception as e:  # noqa: BLE001 - the HTTP boundary must answer, not leak
+    # The HTTP boundary must answer, not leak.
+    except Exception as e:  # noqa: BLE001
         return __handle_conversion_error(e, chromium_manager, start_time)
     else:
         return response
@@ -639,7 +640,8 @@ async def convert_html_with_attachments(
         output_pdf = await __generate_pdf_from_parsed_html(parsed_html, html_parser, render, output, chromium_manager, attachments)
         response = await __create_response(output, output_pdf)
         __record_conversion_metrics(chromium_manager, start_time, success=True)
-    except Exception as e:  # noqa: BLE001 - same, for the attachments endpoint
+    # Same, for the attachments endpoint.
+    except Exception as e:  # noqa: BLE001
         return __handle_conversion_error(e, chromium_manager, start_time)
     else:
         return response

--- a/scripts/load_test.py
+++ b/scripts/load_test.py
@@ -367,7 +367,8 @@ class LoadTester:
         except httpx.TimeoutException:
             duration_ms = (time.time() - start_time) * 1000
             return RequestStats(status_code=0, duration_ms=duration_ms, success=False, error="Timeout")
-        except Exception as e:  # noqa: BLE001 - any failure is recorded as a failed request
+        # Any failure is recorded as a failed request.
+        except Exception as e:  # noqa: BLE001
             duration_ms = (time.time() - start_time) * 1000
             return RequestStats(status_code=0, duration_ms=duration_ms, success=False, error=str(e))
 
@@ -409,7 +410,8 @@ class LoadTester:
                         )
 
                 queue.task_done()
-            except Exception as e:  # noqa: BLE001 - a worker must survive a single bad request
+            # A worker must survive a single bad request.
+            except Exception as e:  # noqa: BLE001
                 print(f"\nWorker error: {e}", file=sys.stderr)
                 queue.task_done()
 
@@ -676,7 +678,8 @@ def main() -> None:
     except KeyboardInterrupt:
         print("\n\nLoad test interrupted by user", file=sys.stderr)
         sys.exit(1)
-    except Exception as e:  # noqa: BLE001 - the CLI reports and exits non-zero
+    # The CLI reports and exits non-zero.
+    except Exception as e:  # noqa: BLE001
         print(f"\nError: {e}", file=sys.stderr)
         sys.exit(1)
 

--- a/tests/test_container_memory.py
+++ b/tests/test_container_memory.py
@@ -84,7 +84,8 @@ def container_reclaim_disabled(docker_image):
     yield container, f"http://localhost:{host_port}"
     try:
         container.stop()
-    except Exception:  # noqa: BLE001 - teardown is best effort
+    # Teardown is best effort.
+    except Exception:  # noqa: BLE001
         logger.warning("Failed to stop container %s", container.id[:12])
 
 
@@ -107,7 +108,8 @@ def container_reclaim_enabled(docker_image):
     yield container, f"http://localhost:{host_port}"
     try:
         container.stop()
-    except Exception:  # noqa: BLE001 - teardown is best effort
+    # Teardown is best effort.
+    except Exception:  # noqa: BLE001
         logger.warning("Failed to stop container %s", container.id[:12])
 
 

--- a/tests/test_svg_processor.py
+++ b/tests/test_svg_processor.py
@@ -3,7 +3,9 @@
 from pathlib import Path
 
 import pytest
-from defusedxml import ElementTree as det  # noqa: N813 - defusedxml exposes ElementTree as a module
+
+# Defusedxml exposes ElementTree as a module.
+from defusedxml import ElementTree as det  # noqa: N813
 
 from app.html_parser import HtmlParser
 from app.svg_processor import SvgProcessor


### PR DESCRIPTION
Sonar's `python:S7632` reads trailing text inside a suppression comment as broken
syntax. Ruff parses the codes and ignores the rest, so the two disagreed wherever
a `# noqa` carried its reason inline:

```python
except Exception:  # noqa: BLE001 - sanitization must never fail
```

The directive now carries codes only and the reason moves to the line above,
which both tools accept. Verified that ruff still suppresses in that shape.

The reasons themselves are unchanged; this is where they sit, not what they say.

Verified: ruff clean, format clean, mypy clean, tests pass.