### PR TITLE
fix: vet every external resource before loading it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,6 +195,10 @@ grype weasyprint-service:0.0.0
 - `WEASYPRINT_SERVICE_VERSION`: Service version (set during build)
 - `WEASYPRINT_SERVICE_BUILD_TIMESTAMP`: Build timestamp (set during build)
 
+**External resources (see `app/external_resources.py`):**
+- `EXTERNAL_RESOURCES_POLICY` (BLOCK_INTERNAL default / ALLOWLIST_ONLY / ALLOW_ALL), `EXTERNAL_RESOURCES_ALLOWED_ORIGINS` (`[scheme://]host[:port]`, comma separated), `EXTERNAL_RESOURCES_MAX_SIZE_MB` (16), `EXTERNAL_RESOURCES_TIMEOUT_SECONDS` (10).
+- `PolicyUrlFetcher` is passed to every `weasyprint.HTML(...)` call: addresses are vetted and pinned, redirects re-vetted, bodies capped and restricted to images, fonts and stylesheets. `file:` is refused outside the request temporary directory, which is what makes `/convert/html-with-attachments` keep working.
+
 **TLS (see `app/tls.py`):**
 - `TLS_CERT_FILE`, `TLS_KEY_FILE`, `TLS_KEY_PASSWORD`, `TLS_CLIENT_CA_FILE`, `TLS_CLIENT_AUTH` (none/optional/required): serve the API over HTTPS. Unset means plain HTTP (default).
 - `METRICS_TLS_*`: the same five for the metrics server, configured independently. Neither set inherits from the other.

--- a/README.md
+++ b/README.md
@@ -419,7 +419,7 @@ Every load therefore goes through a policy. By default the service refuses every
 | `EXTERNAL_RESOURCES_POLICY` | `BLOCK_INTERNAL` | `BLOCK_INTERNAL`, `ALLOWLIST_ONLY` or `ALLOW_ALL` |
 | `EXTERNAL_RESOURCES_ALLOWED_ORIGINS` | empty | Comma separated origins which are allowed whatever they resolve to |
 | `EXTERNAL_RESOURCES_MAX_SIZE_MB` | `16` | Size a single resource may reach |
-| `EXTERNAL_RESOURCES_TIMEOUT_SECONDS` | `10` | Time a single request may take |
+| `EXTERNAL_RESOURCES_TIMEOUT_SECONDS` | `10` | Time the whole load of one resource may take, its redirects and its address attempts included |
 
 To load resources from an internal host, list its origin:
 

--- a/README.md
+++ b/README.md
@@ -408,6 +408,51 @@ docker run --detach \
 --volume /path/to/logs:/opt/weasyprint/logs
 ```
 
+### External resources of a document
+
+A document names its own resources: an image, a font, a stylesheet. WeasyPrint loads what it names, so a document reaching this service can make it read an address of the network it sits in, and `<link rel="attachment">` returns the answer inside the produced PDF.
+
+Every load therefore goes through a policy. By default the service refuses every address which is not public: loopback, private ranges, link local including the cloud metadata address `169.254.169.254`, and their IPv6 equivalents.
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `EXTERNAL_RESOURCES_POLICY` | `BLOCK_INTERNAL` | `BLOCK_INTERNAL`, `ALLOWLIST_ONLY` or `ALLOW_ALL` |
+| `EXTERNAL_RESOURCES_ALLOWED_ORIGINS` | empty | Comma separated origins which are allowed whatever they resolve to |
+| `EXTERNAL_RESOURCES_MAX_SIZE_MB` | `16` | Size a single resource may reach |
+| `EXTERNAL_RESOURCES_TIMEOUT_SECONDS` | `10` | Time a single request may take |
+
+To load resources from an internal host, list its origin:
+
+```properties
+EXTERNAL_RESOURCES_ALLOWED_ORIGINS=cdn.intranet,https://images.intranet:8443
+```
+
+An entry is written `[scheme://]host[:port]`, and what it leaves out is not compared:
+
+| Entry | What it allows |
+| --- | --- |
+| `cdn.intranet` | that host under either scheme, on any port |
+| `cdn.intranet:8443` | that host on port 8443, under either scheme |
+| `https://cdn.intranet` | that host under https, on port 443 |
+| `https://cdn.intranet:8443` | that host under https, on port 8443 |
+
+The three policies:
+
+```bash
+# BLOCK_INTERNAL (default) - public addresses and the allowed origins
+# ALLOWLIST_ONLY           - only the allowed origins
+# ALLOW_ALL                - no restriction, this exposes the network of the service to whoever writes a document
+-e EXTERNAL_RESOURCES_POLICY=ALLOWLIST_ONLY
+```
+
+**How a request is made.** The name is resolved, every address it answers with is checked, and the request is bound to what was checked, so a second lookup cannot answer differently. Every redirect hop is checked again, at most five of them. A loaded resource has to be an image, a font or a stylesheet, by the declared type and, where a server declares none, by the content itself. That last rule is what closes `<link rel="attachment">` as a way to read a body back.
+
+**Schemes.** `data:` passes, it carries its own content. `file:` is refused, except for the files uploaded with a request to `/convert/html-with-attachments`, which the service itself put in a temporary directory. `ftp:` and everything else are refused.
+
+**Behind a proxy.** A proxy resolves the name itself, so such a request cannot be bound to a checked address. It is made only for a host listed in `EXTERNAL_RESOURCES_ALLOWED_ORIGINS`. Where a proxy is configured for every destination, `BLOCK_INTERNAL` therefore behaves as `ALLOWLIST_ONLY`.
+
+Blocked resources are reported in the log and the document is rendered without them, which is how WeasyPrint treats a resource it cannot load.
+
 ### HTTPS
 
 Both servers speak plain HTTP by default, which is what a deployment behind a reverse proxy or an ingress expects: TLS terminates there and nothing has to be configured here. That remains the recommended setup where such a component is already in place.

--- a/app/external_resources.py
+++ b/app/external_resources.py
@@ -33,8 +33,8 @@ from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
-from urllib.parse import urlsplit, urlunsplit
-from urllib.request import getproxies, proxy_bypass
+from urllib.parse import urljoin, urlsplit, urlunsplit
+from urllib.request import getproxies, proxy_bypass, url2pathname
 
 from weasyprint.urls import URLFetcher, URLFetcherResponse  # type: ignore[import-untyped]
 
@@ -193,6 +193,13 @@ def is_public_address(address: str) -> bool:
     return parsed.is_global and not parsed.is_multicast
 
 
+def tls_context() -> ssl.SSLContext:
+    """The context a request is made with: certificates verified, TLS 1.2 at least."""
+    context = ssl.create_default_context()
+    context.minimum_version = ssl.TLSVersion.TLSv1_2
+    return context
+
+
 def resolve(host: str, port: int) -> tuple[str, ...]:
     """Resolve a host to every address it answers with."""
     try:
@@ -219,17 +226,17 @@ class PolicyUrlFetcher(URLFetcher):
         self.max_size_bytes = get_max_size_bytes()
         self.timeout_seconds = get_timeout_seconds()
 
-    def fetch(self, url: str, headers: dict[str, str] | None = None) -> Any:  # noqa: ARG002 - the base signature
+    def fetch(self, url: str, headers: dict[str, str] | None = None) -> Any:
         """Load a resource, or explain why it may not be loaded."""
         scheme = urlsplit(url).scheme.lower()
 
         if scheme == "data":
-            return super().fetch(url)
+            return super().fetch(url, headers)
         if scheme == "file":
             self._check_file(url)
-            return super().fetch(url)
+            return super().fetch(url, headers)
         if scheme in DEFAULT_PORTS:
-            return self._fetch_remote(url)
+            return self._fetch_remote(url, headers)
 
         raise ExternalResourceError(f"'{scheme}:' is not a scheme a document may load from")
 
@@ -237,7 +244,9 @@ class PolicyUrlFetcher(URLFetcher):
         """A file is readable only under the temporary directory of the request."""
         if self.allowed_file_root is None:
             raise ExternalResourceError("a document may not load a file of this container")
-        path = Path(url.split("?", maxsplit=1)[0].removeprefix("file://")).resolve()
+        # Decoded first: the check has to read the path the loader reads, or
+        # '%2e%2e' walks out of the directory as an ordinary looking component.
+        path = Path(url2pathname(urlsplit(url).path)).resolve()
         if not path.is_relative_to(self.allowed_file_root):
             raise ExternalResourceError("a document may only load the files uploaded with it")
 
@@ -260,6 +269,8 @@ class PolicyUrlFetcher(URLFetcher):
         """
         parts = urlsplit(url)
         scheme = parts.scheme.lower()
+        if scheme not in DEFAULT_PORTS:
+            raise ExternalResourceError(f"'{scheme}:' is not a scheme a document may load from")
         host = parts.hostname or ""
         port = parts.port or DEFAULT_PORTS[scheme]
         if not host:
@@ -289,31 +300,22 @@ class PolicyUrlFetcher(URLFetcher):
             return None
         return proxy
 
-    def _fetch_remote(self, url: str) -> URLFetcherResponse:
+    def _fetch_remote(self, url: str, headers: dict[str, str] | None = None) -> URLFetcherResponse:
         """Load a resource over http, following redirects hop by hop."""
         seen = url
         for _ in range(MAX_REDIRECTS + 1):
             scheme, host, port, address = self._vet(seen)
-            response = self._send(scheme, host, port, address, seen)
+            response = self._send(scheme, host, port, address, seen, headers)
             location = response.getheader("Location") if response.status in HTTP_REDIRECT_RANGE else None
             if location is None:
                 return self._read_response(seen, response)
-            response.read()
+            # A hop carries no resource, and its body is bounded like any other.
+            response.read(self.max_size_bytes)
             response.close()
-            seen = self._absolute(seen, location)
+            seen = urljoin(seen, location)
         raise ExternalResourceError(f"'{url}' redirects more than {MAX_REDIRECTS} times")
 
-    @staticmethod
-    def _absolute(current: str, location: str) -> str:
-        """Resolve a redirect target against the address it came from."""
-        parts = urlsplit(location)
-        if parts.scheme:
-            return location
-        base = urlsplit(current)
-        path = location if location.startswith("/") else f"{base.path.rsplit('/', 1)[0]}/{location}"
-        return urlunsplit((base.scheme, base.netloc, path, "", ""))
-
-    def _send(self, scheme: str, host: str, port: int, address: str | None, url: str) -> http.client.HTTPResponse:
+    def _send(self, scheme: str, host: str, port: int, address: str | None, url: str, headers: dict[str, str] | None = None) -> http.client.HTTPResponse:
         """Send the request, bound to the address which was vetted."""
         parts = urlsplit(url)
         target = urlunsplit(("", "", parts.path or "/", parts.query, ""))
@@ -321,29 +323,43 @@ class PolicyUrlFetcher(URLFetcher):
 
         try:
             if proxy:
-                proxy_parts = urlsplit(proxy if "//" in proxy else f"//{proxy}")
-                connection: http.client.HTTPConnection = http.client.HTTPConnection(proxy_parts.hostname or "", proxy_parts.port or 80, timeout=self.timeout_seconds)
-                if scheme == "https":
-                    connection.set_tunnel(host, port)
-                else:
+                connection = self._through_proxy(proxy, scheme, host, port)
+                if scheme != "https":
                     target = url
-            elif scheme == "https":
-                # The name is what the certificate is checked against, the
-                # address is what the socket connects to.
-                context = ssl.create_default_context()
-                connection = http.client.HTTPSConnection(host, port, timeout=self.timeout_seconds, context=context)
-                plain_socket = socket.create_connection((address, port), timeout=self.timeout_seconds)
-                connection.sock = context.wrap_socket(plain_socket, server_hostname=host)
             else:
-                connection = http.client.HTTPConnection(address or host, port, timeout=self.timeout_seconds)
-                connection.host = host
+                connection = self._direct(scheme, host, port, address)
 
-            connection.request("GET", target, headers={"Host": f"{host}:{port}" if port != DEFAULT_PORTS[scheme] else host, "User-Agent": "weasyprint-service"})
+            request_headers = {"User-Agent": "weasyprint-service", **(headers or {})}
+            request_headers["Host"] = f"{host}:{port}" if port != DEFAULT_PORTS[scheme] else host
+            connection.request("GET", target, headers=request_headers)
             return connection.getresponse()
         except ExternalResourceError:
             raise
         except OSError as e:
             raise ExternalResourceError(f"'{url}' could not be loaded: {e}") from e
+
+    def _through_proxy(self, proxy: str, scheme: str, host: str, port: int) -> http.client.HTTPConnection:
+        """Open the connection a proxy carries, which resolves the name itself."""
+        proxy_parts = urlsplit(proxy if "//" in proxy else f"//{proxy}")
+        connection = http.client.HTTPConnection(proxy_parts.hostname or "", proxy_parts.port or DEFAULT_PORTS["http"], timeout=self.timeout_seconds)
+        if scheme == "https":
+            connection.set_tunnel(host, port)
+        return connection
+
+    def _direct(self, scheme: str, host: str, port: int, address: str | None) -> http.client.HTTPConnection:
+        """Open the connection to the address which was vetted."""
+        if scheme != "https":
+            # The name travels in the Host header, never in the address the
+            # socket connects to, which is what keeps the request pinned.
+            return http.client.HTTPConnection(address or host, port, timeout=self.timeout_seconds)
+
+        # The name is what the certificate is checked against, the address is
+        # what the socket connects to.
+        context = tls_context()
+        connection = http.client.HTTPSConnection(host, port, timeout=self.timeout_seconds, context=context)
+        plain_socket = socket.create_connection((address, port), timeout=self.timeout_seconds)
+        connection.sock = context.wrap_socket(plain_socket, server_hostname=host)
+        return connection
 
     def _read_response(self, url: str, response: http.client.HTTPResponse) -> URLFetcherResponse:
         """Read a body which is of an allowed kind and within the size limit."""

--- a/app/external_resources.py
+++ b/app/external_resources.py
@@ -29,6 +29,7 @@ import os
 import re
 import socket
 import ssl
+import time
 from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
@@ -312,10 +313,11 @@ class PolicyUrlFetcher(URLFetcher):
 
     def _fetch_remote(self, url: str, headers: dict[str, str] | None = None) -> URLFetcherResponse:
         """Load a resource over http, following redirects hop by hop."""
+        deadline = time.monotonic() + self.timeout_seconds
         seen = url
         for _ in range(MAX_REDIRECTS + 1):
             scheme, host, port, addresses = self._vet(seen)
-            response = self._send(scheme, host, port, addresses, seen, headers)
+            response = self._send(scheme, host, port, addresses, seen, headers, deadline)
             location = response.getheader("Location") if response.status in HTTP_REDIRECT_RANGE else None
             if location is None:
                 return self._read_response(seen, response)
@@ -325,63 +327,95 @@ class PolicyUrlFetcher(URLFetcher):
             seen = urljoin(seen, location)
         raise ExternalResourceError(f"'{url}' redirects more than {MAX_REDIRECTS} times")
 
-    def _send(self, scheme: str, host: str, port: int, addresses: tuple[str, ...], url: str, headers: dict[str, str] | None = None) -> http.client.HTTPResponse:
+    def _remaining(self, deadline: float, url: str) -> float:
+        """The time left for a request, or a refusal when there is none."""
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise ExternalResourceError(f"'{url}' took longer than the {self.timeout_seconds} seconds a resource may take")
+        return remaining
+
+    def _send(self, scheme: str, host: str, port: int, addresses: tuple[str, ...], url: str, headers: dict[str, str] | None = None, deadline: float | None = None) -> http.client.HTTPResponse:
         """Send the request, bound to an address which was vetted."""
         parts = urlsplit(url)
         target = urlunsplit(("", "", parts.path or "/", parts.query, ""))
         proxy = self._proxy_for(scheme, host)
         request_headers = {"User-Agent": "weasyprint-service", **(headers or {})}
         request_headers["Host"] = host_header(host, port, scheme)
+        deadline = deadline if deadline is not None else time.monotonic() + self.timeout_seconds
 
         if proxy:
-            try:
-                connection = self._through_proxy(proxy, scheme, host, port)
-                connection.request("GET", url if scheme != "https" else target, headers=request_headers)
-                return connection.getresponse()
-            except OSError as e:
-                raise ExternalResourceError(f"'{url}' could not be loaded: {e}") from e
+            connection = self._through_proxy(proxy, scheme, host, port, self._remaining(deadline, url))
+            return self._ask(connection, url if scheme != "https" else target, request_headers, url)
+
+        # A request is made to an address which was vetted, never to a name: the
+        # name would be resolved again, by whoever answers next.
+        if not addresses:
+            raise ExternalResourceError(f"'{url}' resolved to no address which may be connected to")
 
         # Every address was vetted, so the next one may be tried when a route to
         # the first is missing, which is the common case for a dual stack host.
         last_error: OSError | None = None
-        for address in addresses or (host,):
+        for index, address in enumerate(addresses):
+            # The time left is shared out, so a dead address does not spend the
+            # budget of the one which would have answered.
+            timeout = self._remaining(deadline, url) / (len(addresses) - index)
             try:
-                connection = self._direct(scheme, host, port, address)
-                connection.request("GET", target, headers=request_headers)
-                return connection.getresponse()
+                connection = self._direct(scheme, host, port, address, timeout)
             except OSError as e:
                 last_error = e
+                continue
+            try:
+                return self._ask(connection, target, request_headers, url)
+            except ExternalResourceError as e:
+                last_error = OSError(str(e))
         raise ExternalResourceError(f"'{url}' could not be loaded: {last_error}")
 
-    def _through_proxy(self, proxy: str, scheme: str, host: str, port: int) -> http.client.HTTPConnection:
+    @staticmethod
+    def _ask(connection: http.client.HTTPConnection, target: str, request_headers: dict[str, str], url: str) -> http.client.HTTPResponse:
+        """Send the request, closing the connection when it does not answer."""
+        try:
+            connection.request("GET", target, headers=request_headers)
+            return connection.getresponse()
+        except OSError as e:
+            connection.close()
+            raise ExternalResourceError(f"'{url}' could not be loaded: {e}") from e
+
+    def _through_proxy(self, proxy: str, scheme: str, host: str, port: int, timeout: float | None = None) -> http.client.HTTPConnection:
         """Open the connection a proxy carries, which resolves the name itself."""
         proxy_parts = urlsplit(proxy if "//" in proxy else f"//{proxy}")
         proxy_host = proxy_parts.hostname or ""
         proxy_port = proxy_parts.port or DEFAULT_PORTS["http"]
+        timeout = timeout if timeout is not None else self.timeout_seconds
 
         if scheme != "https":
-            return http.client.HTTPConnection(proxy_host, proxy_port, timeout=self.timeout_seconds)
+            return http.client.HTTPConnection(proxy_host, proxy_port, timeout=timeout)
 
         # An HTTPSConnection wraps the socket after the CONNECT, so the request
         # travels encrypted inside the tunnel. A plain connection with a tunnel
         # would put it there in the clear.
-        connection = http.client.HTTPSConnection(proxy_host, proxy_port, timeout=self.timeout_seconds, context=tls_context())
+        connection = http.client.HTTPSConnection(proxy_host, proxy_port, timeout=timeout, context=tls_context())
         connection.set_tunnel(host, port)
         return connection
 
-    def _direct(self, scheme: str, host: str, port: int, address: str | None) -> http.client.HTTPConnection:
+    def _direct(self, scheme: str, host: str, port: int, address: str, timeout: float | None = None) -> http.client.HTTPConnection:
         """Open the connection to the address which was vetted."""
+        timeout = timeout if timeout is not None else self.timeout_seconds
+
         if scheme != "https":
             # The name travels in the Host header, never in the address the
             # socket connects to, which is what keeps the request pinned.
-            return http.client.HTTPConnection(address or host, port, timeout=self.timeout_seconds)
+            return http.client.HTTPConnection(address, port, timeout=timeout)
 
         # The name is what the certificate is checked against, the address is
         # what the socket connects to.
         context = tls_context()
-        connection = http.client.HTTPSConnection(host, port, timeout=self.timeout_seconds, context=context)
-        plain_socket = socket.create_connection((address, port), timeout=self.timeout_seconds)
-        connection.sock = context.wrap_socket(plain_socket, server_hostname=host)
+        connection = http.client.HTTPSConnection(host, port, timeout=timeout, context=context)
+        plain_socket = socket.create_connection((address, port), timeout=timeout)
+        try:
+            connection.sock = context.wrap_socket(plain_socket, server_hostname=host)
+        except OSError:
+            plain_socket.close()
+            raise
         return connection
 
     def _read_response(self, url: str, response: http.client.HTTPResponse) -> URLFetcherResponse:

--- a/app/external_resources.py
+++ b/app/external_resources.py
@@ -207,9 +207,13 @@ def host_header(host: str, port: int, scheme: str) -> str:
 
 
 def resolve(host: str, port: int) -> tuple[str, ...]:
-    """Resolve a host to every address it answers with."""
+    """Resolve a host to every address it answers with.
+
+    AI_ADDRCONFIG leaves out the families this host has no route for, so a
+    container without IPv6 is not handed an AAAA record to connect to.
+    """
     try:
-        infos = socket.getaddrinfo(host, port, type=socket.SOCK_STREAM)
+        infos = socket.getaddrinfo(host, port, type=socket.SOCK_STREAM, flags=socket.AI_ADDRCONFIG)
     except OSError as e:
         raise ExternalResourceError(f"'{host}' does not resolve: {e}") from e
     return tuple(dict.fromkeys(str(info[4][0]) for info in infos))
@@ -266,12 +270,12 @@ class PolicyUrlFetcher(URLFetcher):
             if not is_public_address(address):
                 raise ExternalResourceError(f"'{host}' resolves to {address}, which is not an address on the internet")
 
-    def _vet(self, url: str) -> tuple[str, str, int, str | None]:
+    def _vet(self, url: str) -> tuple[str, str, int, tuple[str, ...]]:
         """Vet an address and return what a request to it needs.
 
         Returns:
-            The scheme, host, port, and the address to connect to, which is
-            ``None`` when a proxy carries the request and resolves the name.
+            The scheme, host, port, and the addresses which may be connected to,
+            empty when a proxy carries the request and resolves the name itself.
         """
         parts = urlsplit(url)
         scheme = parts.scheme.lower()
@@ -292,12 +296,12 @@ class PolicyUrlFetcher(URLFetcher):
             # configuration trusts by name.
             if self.policy is not ResourcePolicy.ALLOW_ALL and not allowlisted:
                 raise ExternalResourceError(f"'{host}' is reached through a proxy, so it has to be listed in {ALLOWED_ORIGINS_VAR}")
-            return scheme, host, port, None
+            return scheme, host, port, ()
 
         addresses = resolve(host, port)
         if self.policy is ResourcePolicy.BLOCK_INTERNAL and not allowlisted:
             self._check_addresses(addresses, host)
-        return scheme, host, port, addresses[0]
+        return scheme, host, port, addresses
 
     def _proxy_for(self, scheme: str, host: str) -> str | None:
         """The proxy configured for this destination, if any."""
@@ -310,8 +314,8 @@ class PolicyUrlFetcher(URLFetcher):
         """Load a resource over http, following redirects hop by hop."""
         seen = url
         for _ in range(MAX_REDIRECTS + 1):
-            scheme, host, port, address = self._vet(seen)
-            response = self._send(scheme, host, port, address, seen, headers)
+            scheme, host, port, addresses = self._vet(seen)
+            response = self._send(scheme, host, port, addresses, seen, headers)
             location = response.getheader("Location") if response.status in HTTP_REDIRECT_RANGE else None
             if location is None:
                 return self._read_response(seen, response)
@@ -321,35 +325,48 @@ class PolicyUrlFetcher(URLFetcher):
             seen = urljoin(seen, location)
         raise ExternalResourceError(f"'{url}' redirects more than {MAX_REDIRECTS} times")
 
-    def _send(self, scheme: str, host: str, port: int, address: str | None, url: str, headers: dict[str, str] | None = None) -> http.client.HTTPResponse:
-        """Send the request, bound to the address which was vetted."""
+    def _send(self, scheme: str, host: str, port: int, addresses: tuple[str, ...], url: str, headers: dict[str, str] | None = None) -> http.client.HTTPResponse:
+        """Send the request, bound to an address which was vetted."""
         parts = urlsplit(url)
         target = urlunsplit(("", "", parts.path or "/", parts.query, ""))
         proxy = self._proxy_for(scheme, host)
+        request_headers = {"User-Agent": "weasyprint-service", **(headers or {})}
+        request_headers["Host"] = host_header(host, port, scheme)
 
-        try:
-            if proxy:
+        if proxy:
+            try:
                 connection = self._through_proxy(proxy, scheme, host, port)
-                if scheme != "https":
-                    target = url
-            else:
-                connection = self._direct(scheme, host, port, address)
+                connection.request("GET", url if scheme != "https" else target, headers=request_headers)
+                return connection.getresponse()
+            except OSError as e:
+                raise ExternalResourceError(f"'{url}' could not be loaded: {e}") from e
 
-            request_headers = {"User-Agent": "weasyprint-service", **(headers or {})}
-            request_headers["Host"] = host_header(host, port, scheme)
-            connection.request("GET", target, headers=request_headers)
-            return connection.getresponse()
-        except ExternalResourceError:
-            raise
-        except OSError as e:
-            raise ExternalResourceError(f"'{url}' could not be loaded: {e}") from e
+        # Every address was vetted, so the next one may be tried when a route to
+        # the first is missing, which is the common case for a dual stack host.
+        last_error: OSError | None = None
+        for address in addresses or (host,):
+            try:
+                connection = self._direct(scheme, host, port, address)
+                connection.request("GET", target, headers=request_headers)
+                return connection.getresponse()
+            except OSError as e:
+                last_error = e
+        raise ExternalResourceError(f"'{url}' could not be loaded: {last_error}")
 
     def _through_proxy(self, proxy: str, scheme: str, host: str, port: int) -> http.client.HTTPConnection:
         """Open the connection a proxy carries, which resolves the name itself."""
         proxy_parts = urlsplit(proxy if "//" in proxy else f"//{proxy}")
-        connection = http.client.HTTPConnection(proxy_parts.hostname or "", proxy_parts.port or DEFAULT_PORTS["http"], timeout=self.timeout_seconds)
-        if scheme == "https":
-            connection.set_tunnel(host, port)
+        proxy_host = proxy_parts.hostname or ""
+        proxy_port = proxy_parts.port or DEFAULT_PORTS["http"]
+
+        if scheme != "https":
+            return http.client.HTTPConnection(proxy_host, proxy_port, timeout=self.timeout_seconds)
+
+        # An HTTPSConnection wraps the socket after the CONNECT, so the request
+        # travels encrypted inside the tunnel. A plain connection with a tunnel
+        # would put it there in the clear.
+        connection = http.client.HTTPSConnection(proxy_host, proxy_port, timeout=self.timeout_seconds, context=tls_context())
+        connection.set_tunnel(host, port)
         return connection
 
     def _direct(self, scheme: str, host: str, port: int, address: str | None) -> http.client.HTTPConnection:

--- a/app/external_resources.py
+++ b/app/external_resources.py
@@ -1,0 +1,373 @@
+"""Policy for the external resources a document names.
+
+A document reaching this service can name an absolute address for an image, a
+font or a stylesheet, and WeasyPrint loads it. Left alone, that turns the
+service into a fetcher for whatever its network reaches, and ``<link
+rel="attachment">`` returns the answer inside the produced PDF.
+
+Every load therefore goes through :class:`PolicyUrlFetcher`:
+
+- ``data:`` is local and passes untouched.
+- ``file:`` is refused, except under the temporary directory of the request,
+  where the attachments endpoint puts the files it received itself.
+- ``http`` and ``https`` are vetted address by address, and the request is bound
+  to what was vetted, so a second name lookup cannot answer differently. Every
+  redirect hop is vetted again. The body is capped, and its kind has to be an
+  image, a font or a stylesheet.
+- Every other scheme, ``ftp:`` among them, is refused.
+
+Three variables configure it: ``EXTERNAL_RESOURCES_POLICY``,
+``EXTERNAL_RESOURCES_ALLOWED_ORIGINS`` and ``EXTERNAL_RESOURCES_MAX_SIZE_MB``.
+"""
+
+from __future__ import annotations
+
+import http.client
+import ipaddress
+import logging
+import os
+import re
+import socket
+import ssl
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+from urllib.parse import urlsplit, urlunsplit
+from urllib.request import getproxies, proxy_bypass
+
+from weasyprint.urls import URLFetcher, URLFetcherResponse  # type: ignore[import-untyped]
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+logger = logging.getLogger(__name__)
+
+POLICY_VAR = "EXTERNAL_RESOURCES_POLICY"
+ALLOWED_ORIGINS_VAR = "EXTERNAL_RESOURCES_ALLOWED_ORIGINS"
+MAX_SIZE_MB_VAR = "EXTERNAL_RESOURCES_MAX_SIZE_MB"
+TIMEOUT_VAR = "EXTERNAL_RESOURCES_TIMEOUT_SECONDS"
+
+DEFAULT_MAX_SIZE_MB = 16
+DEFAULT_TIMEOUT_SECONDS = 10
+MAX_REDIRECTS = 5
+HTTP_OK = 200
+HTTP_REDIRECT_RANGE = range(300, 400)
+DEFAULT_PORTS = {"http": 80, "https": 443}
+
+# What a document may load: an image, a font or a stylesheet. Anything else is
+# not a resource of a page, it is a body someone wants read back.
+ALLOWED_CONTENT_TYPES = ("image/", "font/", "application/font", "application/x-font", "application/vnd.ms-fontobject", "text/css")
+UNDECLARED_CONTENT_TYPES = ("application/octet-stream", "binary/octet-stream", "")
+
+# Signatures of the kinds above, for a server which declares nothing useful.
+CONTENT_SIGNATURES = (
+    b"\x89PNG\r\n\x1a\n",  # PNG
+    b"\xff\xd8\xff",  # JPEG
+    b"GIF87a",
+    b"GIF89a",
+    b"BM",  # BMP
+    b"\x00\x00\x01\x00",  # ICO
+    b"II*\x00",  # TIFF little endian
+    b"MM\x00*",  # TIFF big endian
+    b"wOFF",
+    b"wOF2",
+    b"\x00\x01\x00\x00",  # TrueType
+    b"OTTO",  # OpenType
+    b"ttcf",  # TrueType collection
+)
+RIFF_SIGNATURE = b"RIFF"
+WEBP_SIGNATURE = b"WEBP"
+
+ORIGIN_PATTERN = re.compile(r"^(?:(?P<scheme>https?)://)?(?P<host>\[[^\]]+\]|[^:/\s]+)(?::(?P<port>\d+))?$", re.IGNORECASE)
+
+
+class ExternalResourceError(ValueError):
+    """Raised when a resource may not be loaded, with the reason."""
+
+
+class ResourcePolicy(StrEnum):
+    """Where a document may load a resource from."""
+
+    BLOCK_INTERNAL = "BLOCK_INTERNAL"
+    ALLOWLIST_ONLY = "ALLOWLIST_ONLY"
+    ALLOW_ALL = "ALLOW_ALL"
+
+
+@dataclass(frozen=True)
+class Origin:
+    """An entry of the allowed origins, written ``[scheme://]host[:port]``.
+
+    What an entry leaves out is not compared: ``cdn.intranet`` allows that host
+    under either scheme on any port.
+    """
+
+    host: str
+    scheme: str | None = None
+    port: int | None = None
+
+    @classmethod
+    def parse(cls, value: str) -> Origin:
+        match = ORIGIN_PATTERN.match(value.strip())
+        if not match:
+            raise ExternalResourceError(f"'{value}' is not a valid entry of {ALLOWED_ORIGINS_VAR}, expected [scheme://]host[:port]")
+        scheme = match["scheme"].lower() if match["scheme"] else None
+        if match["port"]:
+            port = int(match["port"])
+        elif scheme:
+            port = DEFAULT_PORTS[scheme]
+        else:
+            port = None
+        return cls(host=match["host"].strip("[]").lower(), scheme=scheme, port=port)
+
+    def matches(self, scheme: str, host: str, port: int) -> bool:
+        if self.host != host.strip("[]").lower():
+            return False
+        if self.scheme and self.scheme != scheme:
+            return False
+        return not (self.port and self.port != port)
+
+
+def _read(name: str) -> str:
+    return os.environ.get(name, "").strip()
+
+
+def get_policy() -> ResourcePolicy:
+    """Read the configured policy, falling back to the closed one."""
+    configured = _read(POLICY_VAR).upper()
+    if not configured:
+        return ResourcePolicy.BLOCK_INTERNAL
+    try:
+        return ResourcePolicy(configured)
+    except ValueError:
+        allowed = ", ".join(policy.value for policy in ResourcePolicy)
+        logger.warning("%s is '%s', expected one of: %s. Falling back to %s", POLICY_VAR, configured, allowed, ResourcePolicy.BLOCK_INTERNAL.value)
+        return ResourcePolicy.BLOCK_INTERNAL
+
+
+def get_allowed_origins() -> tuple[Origin, ...]:
+    """Read the origins which are allowed whatever they resolve to."""
+    raw = _read(ALLOWED_ORIGINS_VAR)
+    return tuple(Origin.parse(entry) for entry in raw.split(",") if entry.strip())
+
+
+def get_max_size_bytes() -> int:
+    """Read the size a single resource may reach."""
+    configured = _read(MAX_SIZE_MB_VAR)
+    if not configured:
+        return DEFAULT_MAX_SIZE_MB * 1024 * 1024
+    try:
+        megabytes = int(configured)
+    except ValueError:
+        logger.warning("%s is '%s', which is not a number. Falling back to %d", MAX_SIZE_MB_VAR, configured, DEFAULT_MAX_SIZE_MB)
+        return DEFAULT_MAX_SIZE_MB * 1024 * 1024
+    if megabytes <= 0:
+        logger.warning("%s is '%s', which is not positive. Falling back to %d", MAX_SIZE_MB_VAR, configured, DEFAULT_MAX_SIZE_MB)
+        return DEFAULT_MAX_SIZE_MB * 1024 * 1024
+    return megabytes * 1024 * 1024
+
+
+def get_timeout_seconds() -> float:
+    """Read the time a single request may take."""
+    configured = _read(TIMEOUT_VAR)
+    try:
+        timeout = float(configured) if configured else DEFAULT_TIMEOUT_SECONDS
+    except ValueError:
+        logger.warning("%s is '%s', which is not a number. Falling back to %d", TIMEOUT_VAR, configured, DEFAULT_TIMEOUT_SECONDS)
+        return DEFAULT_TIMEOUT_SECONDS
+    return timeout if timeout > 0 else DEFAULT_TIMEOUT_SECONDS
+
+
+def is_public_address(address: str) -> bool:
+    """Whether an address names a host on the internet.
+
+    Loopback, private ranges, link local (the cloud metadata address among them),
+    the unspecified address and everything reserved are not.
+    """
+    try:
+        parsed = ipaddress.ip_address(address)
+    except ValueError:
+        return False
+    if isinstance(parsed, ipaddress.IPv6Address) and parsed.ipv4_mapped:
+        parsed = parsed.ipv4_mapped
+    return parsed.is_global and not parsed.is_multicast
+
+
+def resolve(host: str, port: int) -> tuple[str, ...]:
+    """Resolve a host to every address it answers with."""
+    try:
+        infos = socket.getaddrinfo(host, port, type=socket.SOCK_STREAM)
+    except OSError as e:
+        raise ExternalResourceError(f"'{host}' does not resolve: {e}") from e
+    return tuple(dict.fromkeys(str(info[4][0]) for info in infos))
+
+
+class PolicyUrlFetcher(URLFetcher):
+    """The fetcher WeasyPrint loads every external resource with."""
+
+    def __init__(self, allowed_file_root: Path | None = None) -> None:
+        """
+        Args:
+            allowed_file_root: Directory whose files may be loaded through
+                ``file:``, which is the temporary directory of a request with
+                attachments. Nothing outside it is readable.
+        """
+        super().__init__(allow_redirects=False)
+        self.allowed_file_root = allowed_file_root.resolve() if allowed_file_root else None
+        self.policy = get_policy()
+        self.allowed_origins = get_allowed_origins()
+        self.max_size_bytes = get_max_size_bytes()
+        self.timeout_seconds = get_timeout_seconds()
+
+    def fetch(self, url: str, headers: dict[str, str] | None = None) -> Any:  # noqa: ARG002 - the base signature
+        """Load a resource, or explain why it may not be loaded."""
+        scheme = urlsplit(url).scheme.lower()
+
+        if scheme == "data":
+            return super().fetch(url)
+        if scheme == "file":
+            self._check_file(url)
+            return super().fetch(url)
+        if scheme in DEFAULT_PORTS:
+            return self._fetch_remote(url)
+
+        raise ExternalResourceError(f"'{scheme}:' is not a scheme a document may load from")
+
+    def _check_file(self, url: str) -> None:
+        """A file is readable only under the temporary directory of the request."""
+        if self.allowed_file_root is None:
+            raise ExternalResourceError("a document may not load a file of this container")
+        path = Path(url.split("?", maxsplit=1)[0].removeprefix("file://")).resolve()
+        if not path.is_relative_to(self.allowed_file_root):
+            raise ExternalResourceError("a document may only load the files uploaded with it")
+
+    def _check_origin(self, scheme: str, host: str, port: int) -> bool:
+        """Whether the origin is one the configuration allows whatever it resolves to."""
+        return any(origin.matches(scheme, host, port) for origin in self.allowed_origins)
+
+    def _check_addresses(self, addresses: Iterable[str], host: str) -> None:
+        """Every address a host answers with has to be public."""
+        for address in addresses:
+            if not is_public_address(address):
+                raise ExternalResourceError(f"'{host}' resolves to {address}, which is not an address on the internet")
+
+    def _vet(self, url: str) -> tuple[str, str, int, str | None]:
+        """Vet an address and return what a request to it needs.
+
+        Returns:
+            The scheme, host, port, and the address to connect to, which is
+            ``None`` when a proxy carries the request and resolves the name.
+        """
+        parts = urlsplit(url)
+        scheme = parts.scheme.lower()
+        host = parts.hostname or ""
+        port = parts.port or DEFAULT_PORTS[scheme]
+        if not host:
+            raise ExternalResourceError(f"'{url}' names no host")
+
+        allowlisted = self._check_origin(scheme, host, port)
+        if self.policy is ResourcePolicy.ALLOWLIST_ONLY and not allowlisted:
+            raise ExternalResourceError(f"'{host}' is not listed in {ALLOWED_ORIGINS_VAR}")
+
+        if self._proxy_for(scheme, host):
+            # A proxy resolves the name itself, so the request cannot be bound to
+            # an address this side checked. It is made only for a host the
+            # configuration trusts by name.
+            if self.policy is not ResourcePolicy.ALLOW_ALL and not allowlisted:
+                raise ExternalResourceError(f"'{host}' is reached through a proxy, so it has to be listed in {ALLOWED_ORIGINS_VAR}")
+            return scheme, host, port, None
+
+        addresses = resolve(host, port)
+        if self.policy is ResourcePolicy.BLOCK_INTERNAL and not allowlisted:
+            self._check_addresses(addresses, host)
+        return scheme, host, port, addresses[0]
+
+    def _proxy_for(self, scheme: str, host: str) -> str | None:
+        """The proxy configured for this destination, if any."""
+        proxy = getproxies().get(scheme)
+        if not proxy or proxy_bypass(host):
+            return None
+        return proxy
+
+    def _fetch_remote(self, url: str) -> URLFetcherResponse:
+        """Load a resource over http, following redirects hop by hop."""
+        seen = url
+        for _ in range(MAX_REDIRECTS + 1):
+            scheme, host, port, address = self._vet(seen)
+            response = self._send(scheme, host, port, address, seen)
+            location = response.getheader("Location") if response.status in HTTP_REDIRECT_RANGE else None
+            if location is None:
+                return self._read_response(seen, response)
+            response.read()
+            response.close()
+            seen = self._absolute(seen, location)
+        raise ExternalResourceError(f"'{url}' redirects more than {MAX_REDIRECTS} times")
+
+    @staticmethod
+    def _absolute(current: str, location: str) -> str:
+        """Resolve a redirect target against the address it came from."""
+        parts = urlsplit(location)
+        if parts.scheme:
+            return location
+        base = urlsplit(current)
+        path = location if location.startswith("/") else f"{base.path.rsplit('/', 1)[0]}/{location}"
+        return urlunsplit((base.scheme, base.netloc, path, "", ""))
+
+    def _send(self, scheme: str, host: str, port: int, address: str | None, url: str) -> http.client.HTTPResponse:
+        """Send the request, bound to the address which was vetted."""
+        parts = urlsplit(url)
+        target = urlunsplit(("", "", parts.path or "/", parts.query, ""))
+        proxy = self._proxy_for(scheme, host)
+
+        try:
+            if proxy:
+                proxy_parts = urlsplit(proxy if "//" in proxy else f"//{proxy}")
+                connection: http.client.HTTPConnection = http.client.HTTPConnection(proxy_parts.hostname or "", proxy_parts.port or 80, timeout=self.timeout_seconds)
+                if scheme == "https":
+                    connection.set_tunnel(host, port)
+                else:
+                    target = url
+            elif scheme == "https":
+                # The name is what the certificate is checked against, the
+                # address is what the socket connects to.
+                context = ssl.create_default_context()
+                connection = http.client.HTTPSConnection(host, port, timeout=self.timeout_seconds, context=context)
+                plain_socket = socket.create_connection((address, port), timeout=self.timeout_seconds)
+                connection.sock = context.wrap_socket(plain_socket, server_hostname=host)
+            else:
+                connection = http.client.HTTPConnection(address or host, port, timeout=self.timeout_seconds)
+                connection.host = host
+
+            connection.request("GET", target, headers={"Host": f"{host}:{port}" if port != DEFAULT_PORTS[scheme] else host, "User-Agent": "weasyprint-service"})
+            return connection.getresponse()
+        except ExternalResourceError:
+            raise
+        except OSError as e:
+            raise ExternalResourceError(f"'{url}' could not be loaded: {e}") from e
+
+    def _read_response(self, url: str, response: http.client.HTTPResponse) -> URLFetcherResponse:
+        """Read a body which is of an allowed kind and within the size limit."""
+        with response:
+            if response.status != HTTP_OK:
+                raise ExternalResourceError(f"'{url}' answered {response.status}")
+
+            declared = (response.getheader("Content-Type") or "").split(";")[0].strip().lower()
+            if declared and not declared.startswith(ALLOWED_CONTENT_TYPES) and declared not in UNDECLARED_CONTENT_TYPES:
+                raise ExternalResourceError(f"'{url}' is served as '{declared}', which is not an image, a font or a stylesheet")
+
+            body = response.read(self.max_size_bytes + 1)
+            if len(body) > self.max_size_bytes:
+                raise ExternalResourceError(f"'{url}' is larger than the {self.max_size_bytes // (1024 * 1024)} MB a resource may reach")
+
+            if declared in UNDECLARED_CONTENT_TYPES and not _looks_like_a_resource(body):
+                raise ExternalResourceError(f"'{url}' declares no usable content type and its body is not an image or a font")
+
+            headers = {"Content-Type": declared or "application/octet-stream"}
+            return URLFetcherResponse(url=url, body=body, headers=headers, status=response.status)
+
+
+def _looks_like_a_resource(body: bytes) -> bool:
+    """Whether a body a server declared nothing about is an image or a font."""
+    if body.startswith(CONTENT_SIGNATURES):
+        return True
+    return body.startswith(RIFF_SIGNATURE) and body[8:12] == WEBP_SIGNATURE

--- a/app/external_resources.py
+++ b/app/external_resources.py
@@ -200,6 +200,12 @@ def tls_context() -> ssl.SSLContext:
     return context
 
 
+def host_header(host: str, port: int, scheme: str) -> str:
+    """The Host header of a request, with an IPv6 literal in the brackets it needs."""
+    literal = f"[{host}]" if ":" in host else host
+    return literal if port == DEFAULT_PORTS[scheme] else f"{literal}:{port}"
+
+
 def resolve(host: str, port: int) -> tuple[str, ...]:
     """Resolve a host to every address it answers with."""
     try:
@@ -330,7 +336,7 @@ class PolicyUrlFetcher(URLFetcher):
                 connection = self._direct(scheme, host, port, address)
 
             request_headers = {"User-Agent": "weasyprint-service", **(headers or {})}
-            request_headers["Host"] = f"{host}:{port}" if port != DEFAULT_PORTS[scheme] else host
+            request_headers["Host"] = host_header(host, port, scheme)
             connection.request("GET", target, headers=request_headers)
             return connection.getresponse()
         except ExternalResourceError:

--- a/app/external_resources.py
+++ b/app/external_resources.py
@@ -52,6 +52,7 @@ TIMEOUT_VAR = "EXTERNAL_RESOURCES_TIMEOUT_SECONDS"
 DEFAULT_MAX_SIZE_MB = 16
 DEFAULT_TIMEOUT_SECONDS = 10
 MAX_REDIRECTS = 5
+READ_CHUNK_BYTES = 64 * 1024
 HTTP_OK = 200
 HTTP_REDIRECT_RANGE = range(300, 400)
 DEFAULT_PORTS = {"http": 80, "https": 443}
@@ -317,10 +318,10 @@ class PolicyUrlFetcher(URLFetcher):
         seen = url
         for _ in range(MAX_REDIRECTS + 1):
             scheme, host, port, addresses = self._vet(seen)
-            response = self._send(scheme, host, port, addresses, seen, headers, deadline)
+            connection, response = self._send(scheme, host, port, addresses, seen, headers, deadline)
             location = response.getheader("Location") if response.status in HTTP_REDIRECT_RANGE else None
             if location is None:
-                return self._read_response(seen, response)
+                return self._read_response(seen, response, connection, deadline)
             # A hop carries no resource, and its body is bounded like any other.
             response.read(self.max_size_bytes)
             response.close()
@@ -334,7 +335,7 @@ class PolicyUrlFetcher(URLFetcher):
             raise ExternalResourceError(f"'{url}' took longer than the {self.timeout_seconds} seconds a resource may take")
         return remaining
 
-    def _send(self, scheme: str, host: str, port: int, addresses: tuple[str, ...], url: str, headers: dict[str, str] | None = None, deadline: float | None = None) -> http.client.HTTPResponse:
+    def _send(self, scheme: str, host: str, port: int, addresses: tuple[str, ...], url: str, headers: dict[str, str] | None = None, deadline: float | None = None) -> tuple[http.client.HTTPConnection, http.client.HTTPResponse]:
         """Send the request, bound to an address which was vetted."""
         parts = urlsplit(url)
         target = urlunsplit(("", "", parts.path or "/", parts.query, ""))
@@ -371,11 +372,11 @@ class PolicyUrlFetcher(URLFetcher):
         raise ExternalResourceError(f"'{url}' could not be loaded: {last_error}")
 
     @staticmethod
-    def _ask(connection: http.client.HTTPConnection, target: str, request_headers: dict[str, str], url: str) -> http.client.HTTPResponse:
+    def _ask(connection: http.client.HTTPConnection, target: str, request_headers: dict[str, str], url: str) -> tuple[http.client.HTTPConnection, http.client.HTTPResponse]:
         """Send the request, closing the connection when it does not answer."""
         try:
             connection.request("GET", target, headers=request_headers)
-            return connection.getresponse()
+            return connection, connection.getresponse()
         except OSError as e:
             connection.close()
             raise ExternalResourceError(f"'{url}' could not be loaded: {e}") from e
@@ -418,7 +419,24 @@ class PolicyUrlFetcher(URLFetcher):
             raise
         return connection
 
-    def _read_response(self, url: str, response: http.client.HTTPResponse) -> URLFetcherResponse:
+    def _read_body(self, url: str, response: http.client.HTTPResponse, connection: http.client.HTTPConnection, deadline: float) -> bytes:
+        """Read a body under the deadline of the load, not under a timer each byte resets."""
+        chunks: list[bytes] = []
+        size = 0
+        while size <= self.max_size_bytes:
+            remaining = self._remaining(deadline, url)
+            if connection.sock is not None:
+                connection.sock.settimeout(remaining)
+            # read1 returns what one read of the socket gave, so the deadline is
+            # looked at again for every piece rather than once a buffer is full.
+            chunk = response.read1(min(READ_CHUNK_BYTES, self.max_size_bytes + 1 - size))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            size += len(chunk)
+        return b"".join(chunks)
+
+    def _read_response(self, url: str, response: http.client.HTTPResponse, connection: http.client.HTTPConnection, deadline: float) -> URLFetcherResponse:
         """Read a body which is of an allowed kind and within the size limit."""
         with response:
             if response.status != HTTP_OK:
@@ -428,7 +446,7 @@ class PolicyUrlFetcher(URLFetcher):
             if declared and not declared.startswith(ALLOWED_CONTENT_TYPES) and declared not in UNDECLARED_CONTENT_TYPES:
                 raise ExternalResourceError(f"'{url}' is served as '{declared}', which is not an image, a font or a stylesheet")
 
-            body = response.read(self.max_size_bytes + 1)
+            body = self._read_body(url, response, connection, deadline)
             if len(body) > self.max_size_bytes:
                 raise ExternalResourceError(f"'{url}' is larger than the {self.max_size_bytes // (1024 * 1024)} MB a resource may reach")
 

--- a/app/weasyprint_controller.py
+++ b/app/weasyprint_controller.py
@@ -29,6 +29,7 @@ from app.attachment_manager import AttachmentManager
 from app.auth import require_api_key
 from app.chromium_manager import ChromiumManager, get_chromium_manager
 from app.constants import API_VERSION
+from app.external_resources import PolicyUrlFetcher
 from app.form_parser import FormParser
 from app.html_parser import HtmlParser
 from app.metrics_server import MetricsServer, get_metrics_port, is_metrics_server_enabled
@@ -456,6 +457,7 @@ async def __generate_pdf_from_parsed_html(
     output: OutputOptions,
     chromium_manager: ChromiumManager,
     attachments: list | None = None,
+    attachments_dir: Path | None = None,
 ) -> bytes:
     """
     Generate PDF from already-parsed HTML element tree.
@@ -491,11 +493,16 @@ async def __generate_pdf_from_parsed_html(
     if base_url:
         logger.debug("Using base URL: %s", sanitize_url_for_logging(base_url))
 
+    # Every resource the document names is loaded through the policy: a document
+    # decides what to reference, it does not decide what this service reaches.
+    url_fetcher = PolicyUrlFetcher(allowed_file_root=attachments_dir)
+
     logger.debug("Creating WeasyPrint HTML object with media_type=%s", render.media_type)
     weasyprint_html = weasyprint.HTML(
         string=processed_html,
         base_url=base_url,
         media_type=render.media_type,
+        url_fetcher=url_fetcher,
     )
 
     logger.debug(
@@ -642,7 +649,7 @@ async def convert_html_with_attachments(
         )
 
         # Use common PDF generation logic (handles notes, SVG, WeasyPrint)
-        output_pdf = await __generate_pdf_from_parsed_html(parsed_html, html_parser, render, output, chromium_manager, attachments)
+        output_pdf = await __generate_pdf_from_parsed_html(parsed_html, html_parser, render, output, chromium_manager, attachments, attachments_dir=Path(tmpdir))
         response = await __create_response(output, output_pdf)
         __record_conversion_metrics(chromium_manager, start_time, success=True)
     # Same, for the attachments endpoint.

--- a/tests/test_external_resources.py
+++ b/tests/test_external_resources.py
@@ -6,6 +6,7 @@ import http.client
 import http.server
 import ssl
 import threading
+import time
 from collections.abc import Iterator
 from pathlib import Path
 
@@ -437,6 +438,7 @@ def test_a_plain_resource_through_a_proxy_needs_no_tunnel() -> None:
     assert connection._tunnel_host is None
 
 
+@pytest.mark.filterwarnings("error::ResourceWarning")
 def test_the_next_vetted_address_is_tried(monkeypatch: pytest.MonkeyPatch, local_server: str) -> None:
     """A dual stack host answers with an address this container may have no route to."""
     monkeypatch.setenv(POLICY_VAR, ResourcePolicy.ALLOW_ALL.value)
@@ -448,3 +450,27 @@ def test_the_next_vetted_address_is_tried(monkeypatch: pytest.MonkeyPatch, local
     response = PolicyUrlFetcher().fetch(f"http://127.0.0.1:{port}/image.png")
 
     assert response.content_type == "image/png"
+
+
+def test_the_timeout_bounds_the_whole_fetch(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Otherwise the ceiling would be hops times addresses times the configured seconds."""
+    monkeypatch.setenv(POLICY_VAR, ResourcePolicy.ALLOW_ALL.value)
+    monkeypatch.setenv("EXTERNAL_RESOURCES_TIMEOUT_SECONDS", "0.4")
+    # Addresses of the documentation range: reserved, and no route leads there.
+    monkeypatch.setattr("app.external_resources.resolve", lambda host, port: ("192.0.2.1", "192.0.2.2", "192.0.2.3"))
+    fetcher = PolicyUrlFetcher()
+
+    started = time.monotonic()
+    with pytest.raises(ExternalResourceError):
+        fetcher.fetch("http://cdn.example/image.png")
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 2, f"the fetch spent {elapsed:.1f}s, the limit is 0.4s per resource"
+
+
+def test_a_request_is_never_made_to_a_name() -> None:
+    """Without an address there is nothing which was vetted, so there is nothing to ask."""
+    fetcher = PolicyUrlFetcher()
+
+    with pytest.raises(ExternalResourceError, match="no address which may be connected to"):
+        fetcher._send("http", "cdn.example", 80, (), "http://cdn.example/image.png")

--- a/tests/test_external_resources.py
+++ b/tests/test_external_resources.py
@@ -21,6 +21,7 @@ from app.external_resources import (
     get_allowed_origins,
     get_max_size_bytes,
     get_policy,
+    host_header,
     is_public_address,
     tls_context,
 )
@@ -393,3 +394,26 @@ def test_the_tls_context_refuses_the_old_protocol_versions() -> None:
     assert context.minimum_version >= ssl.TLSVersion.TLSv1_2
     assert context.verify_mode == ssl.CERT_REQUIRED
     assert context.check_hostname is True
+
+
+@pytest.mark.parametrize(
+    ("host", "port", "scheme", "expected"),
+    [
+        ("cdn.intranet", 80, "http", "cdn.intranet"),
+        ("cdn.intranet", 8080, "http", "cdn.intranet:8080"),
+        ("cdn.intranet", 443, "https", "cdn.intranet"),
+        ("::1", 80, "http", "[::1]"),
+        ("2001:db8::1", 8443, "https", "[2001:db8::1]:8443"),
+    ],
+)
+def test_the_host_header_carries_the_name(host: str, port: int, scheme: str, expected: str) -> None:
+    """An IPv6 literal needs its brackets, or the header names something else."""
+    assert host_header(host, port, scheme) == expected
+
+
+def test_a_plain_connection_is_bound_to_the_vetted_address() -> None:
+    """The pinning itself: the socket goes to the address, the name only travels in the header."""
+    connection = PolicyUrlFetcher()._direct("http", "cdn.intranet", 80, "93.184.216.34")
+
+    assert connection.host == "93.184.216.34"
+    assert connection.port == 80

--- a/tests/test_external_resources.py
+++ b/tests/test_external_resources.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import http.client
 import http.server
 import ssl
@@ -31,6 +32,9 @@ from app.external_resources import (
 POLICY_VARIABLES = (POLICY_VAR, ALLOWED_ORIGINS_VAR, MAX_SIZE_MB_VAR, "EXTERNAL_RESOURCES_TIMEOUT_SECONDS")
 
 PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 32
+
+# A body announced far larger than it arrives, a byte every 50 ms.
+DRIP_BYTES = 200
 
 REDIRECT_TARGETS = {
     "/redirect-to-image": "/image.png",
@@ -65,6 +69,9 @@ class _Handler(http.server.BaseHTTPRequestHandler):
             "/missing": (404, "text/plain", b"gone"),
         }
         path, _, query = self.path.partition("?")
+        if path == "/dripping.png":
+            self._drip()
+            return
         if path == "/redirect-query-only" and query:
             path = "/image.png"
         elif path in REDIRECT_TARGETS:
@@ -76,6 +83,18 @@ class _Handler(http.server.BaseHTTPRequestHandler):
         self.send_header("Content-Length", str(len(body)))
         self.end_headers()
         self.wfile.write(body)
+
+    def _drip(self) -> None:
+        """Answer a byte at a time, the shape which outlasts a timer each byte resets."""
+        self.send_response(200)
+        self.send_header("Content-Type", "image/png")
+        self.send_header("Content-Length", str(DRIP_BYTES))
+        self.end_headers()
+        with contextlib.suppress(OSError):
+            for _ in range(DRIP_BYTES):
+                self.wfile.write(b"\x00")
+                self.wfile.flush()
+                time.sleep(0.05)
 
     def _redirect(self, path: str) -> None:
         """Answer the redirects the tests follow."""
@@ -91,7 +110,8 @@ class _Handler(http.server.BaseHTTPRequestHandler):
 @pytest.fixture
 def local_server() -> Iterator[str]:
     """A server on the loopback interface, which the policy treats as internal."""
-    server = http.server.HTTPServer(("127.0.0.1", 0), _Handler)
+    # Threading: a handler which answers slowly must not hold the others.
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     try:
@@ -474,3 +494,17 @@ def test_a_request_is_never_made_to_a_name() -> None:
 
     with pytest.raises(ExternalResourceError, match="no address which may be connected to"):
         fetcher._send("http", "cdn.example", 80, (), "http://cdn.example/image.png")
+
+
+def test_a_body_which_arrives_too_slowly_is_given_up(monkeypatch: pytest.MonkeyPatch, local_server: str) -> None:
+    """A server dripping a byte holds the connection past the deadline of the load otherwise."""
+    monkeypatch.setenv(POLICY_VAR, ResourcePolicy.ALLOW_ALL.value)
+    monkeypatch.setenv("EXTERNAL_RESOURCES_TIMEOUT_SECONDS", "0.5")
+    fetcher = PolicyUrlFetcher()
+
+    started = time.monotonic()
+    with pytest.raises(ExternalResourceError, match="took longer than"):
+        fetcher.fetch(f"{local_server}/dripping.png")
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 3, f"the fetch spent {elapsed:.1f}s on a body it should have given up on"

--- a/tests/test_external_resources.py
+++ b/tests/test_external_resources.py
@@ -1,0 +1,338 @@
+"""Tests for the policy applied to the external resources a document names."""
+
+from __future__ import annotations
+
+import http.server
+import threading
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from app.external_resources import (
+    ALLOWED_ORIGINS_VAR,
+    MAX_SIZE_MB_VAR,
+    POLICY_VAR,
+    ExternalResourceError,
+    Origin,
+    PolicyUrlFetcher,
+    ResourcePolicy,
+    get_allowed_origins,
+    get_max_size_bytes,
+    get_policy,
+    is_public_address,
+)
+
+POLICY_VARIABLES = (POLICY_VAR, ALLOWED_ORIGINS_VAR, MAX_SIZE_MB_VAR, "EXTERNAL_RESOURCES_TIMEOUT_SECONDS")
+
+PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 32
+
+
+@pytest.fixture(autouse=True)
+def clean_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Start every test from an unconfigured environment."""
+    for name in POLICY_VARIABLES:
+        monkeypatch.delenv(name, raising=False)
+    for name in ("http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY", "no_proxy", "NO_PROXY"):
+        monkeypatch.delenv(name, raising=False)
+
+
+class _Handler(http.server.BaseHTTPRequestHandler):
+    """Serves the responses the tests need, on the loopback interface."""
+
+    def do_GET(self) -> None:
+        routes = {
+            "/image.png": (200, "image/png", PNG),
+            "/page.html": (200, "text/html", b"<html></html>"),
+            "/secret.txt": (200, "text/plain", b"top secret"),
+            "/undeclared": (200, "application/octet-stream", PNG),
+            "/undeclared-text": (200, "application/octet-stream", b"top secret"),
+            "/huge.png": (200, "image/png", PNG + b"\x00" * (2 * 1024 * 1024)),
+            "/missing": (404, "text/plain", b"gone"),
+        }
+        if self.path.startswith("/redirect"):
+            self._redirect()
+            return
+        status, content_type, body = routes.get(self.path, (404, "text/plain", b"gone"))
+        self.send_response(status)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _redirect(self) -> None:
+        """Answer the redirects the tests follow."""
+        targets = {
+            "/redirect-to-image": "/image.png",
+            "/redirect-to-internal": "http://169.254.169.254/latest/meta-data/",
+            "/redirect-loop": "/redirect-loop",
+        }
+        self.send_response(302)
+        self.send_header("Location", targets.get(self.path, "/image.png"))
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+    def log_message(self, *args: object) -> None:
+        """Keep the test output clean."""
+
+
+@pytest.fixture
+def local_server() -> Iterator[str]:
+    """A server on the loopback interface, which the policy treats as internal."""
+    server = http.server.HTTPServer(("127.0.0.1", 0), _Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_the_closed_policy_is_the_default() -> None:
+    assert get_policy() is ResourcePolicy.BLOCK_INTERNAL
+
+
+def test_an_unknown_policy_falls_back_to_the_closed_one(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(POLICY_VAR, "ALLOW_EVERYTHING")
+
+    assert get_policy() is ResourcePolicy.BLOCK_INTERNAL
+
+
+@pytest.mark.parametrize("configured", ["allowlist_only", "ALLOWLIST_ONLY", " AllowList_Only "])
+def test_the_policy_is_read_regardless_of_case(monkeypatch: pytest.MonkeyPatch, configured: str) -> None:
+    monkeypatch.setenv(POLICY_VAR, configured)
+
+    assert get_policy() is ResourcePolicy.ALLOWLIST_ONLY
+
+
+@pytest.mark.parametrize(
+    ("address", "public"),
+    [
+        ("8.8.8.8", True),
+        ("127.0.0.1", False),
+        ("10.1.2.3", False),
+        ("192.168.1.1", False),
+        ("172.16.0.1", False),
+        ("169.254.169.254", False),  # the cloud metadata address
+        ("0.0.0.0", False),
+        ("::1", False),
+        ("fe80::1", False),
+        ("fd00::1", False),
+        ("::ffff:127.0.0.1", False),  # loopback wearing an IPv6 mapping
+        ("2001:4860:4860::8888", True),
+        ("224.0.0.1", False),  # multicast
+    ],
+)
+def test_which_addresses_are_public(address: str, public: bool) -> None:
+    assert is_public_address(address) is public
+
+
+@pytest.mark.parametrize(
+    ("entry", "scheme", "host", "port", "matches"),
+    [
+        ("cdn.intranet", "http", "cdn.intranet", 80, True),
+        ("cdn.intranet", "https", "cdn.intranet", 8443, True),
+        ("cdn.intranet", "https", "other.intranet", 443, False),
+        ("cdn.intranet:8443", "https", "cdn.intranet", 8443, True),
+        ("cdn.intranet:8443", "https", "cdn.intranet", 443, False),
+        ("https://cdn.intranet", "https", "cdn.intranet", 443, True),
+        ("https://cdn.intranet", "http", "cdn.intranet", 80, False),
+        ("https://cdn.intranet:8443", "https", "cdn.intranet", 8443, True),
+        ("CDN.Intranet", "https", "cdn.intranet", 443, True),
+    ],
+)
+def test_origin_entries(entry: str, scheme: str, host: str, port: int, matches: bool) -> None:
+    assert Origin.parse(entry).matches(scheme, host, port) is matches
+
+
+@pytest.mark.parametrize("entry", ["http://", "host name", "ftp://cdn.intranet", "cdn.intranet:port"])
+def test_an_unusable_origin_entry_is_reported(entry: str) -> None:
+    with pytest.raises(ExternalResourceError, match=ALLOWED_ORIGINS_VAR):
+        Origin.parse(entry)
+
+
+def test_origins_are_read_as_a_list(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(ALLOWED_ORIGINS_VAR, "cdn.intranet, https://images.intranet:8443 , ")
+
+    assert get_allowed_origins() == (Origin(host="cdn.intranet"), Origin(host="images.intranet", scheme="https", port=8443))
+
+
+@pytest.mark.parametrize(("configured", "expected_mb"), [("", 16), ("32", 32), ("zero", 16), ("0", 16), ("-1", 16)])
+def test_the_size_limit_is_read(monkeypatch: pytest.MonkeyPatch, configured: str, expected_mb: int) -> None:
+    if configured:
+        monkeypatch.setenv(MAX_SIZE_MB_VAR, configured)
+
+    assert get_max_size_bytes() == expected_mb * 1024 * 1024
+
+
+@pytest.mark.parametrize("url", ["ftp://example.org/font.ttf", "gopher://example.org/x", "jar:file:///etc/passwd!/x"])
+def test_other_schemes_are_refused(url: str) -> None:
+    fetcher = PolicyUrlFetcher()
+
+    with pytest.raises(ExternalResourceError, match="scheme"):
+        fetcher.fetch(url)
+
+
+def test_a_data_url_passes() -> None:
+    response = PolicyUrlFetcher().fetch("data:image/png;base64,iVBORw0KGgo=")
+
+    assert response.content_type == "image/png"
+
+
+def test_a_file_is_refused_without_an_upload_directory(tmp_path: Path) -> None:
+    secret = tmp_path / "secret.txt"
+    secret.write_text("top secret", encoding="utf-8")
+
+    fetcher = PolicyUrlFetcher()
+    url = secret.as_uri()
+
+    with pytest.raises(ExternalResourceError, match="file of this container"):
+        fetcher.fetch(url)
+
+
+def test_a_file_outside_the_upload_directory_is_refused(tmp_path: Path) -> None:
+    uploads = tmp_path / "uploads"
+    uploads.mkdir()
+    secret = tmp_path / "secret.txt"
+    secret.write_text("top secret", encoding="utf-8")
+
+    fetcher = PolicyUrlFetcher(allowed_file_root=uploads)
+    url = secret.as_uri()
+
+    with pytest.raises(ExternalResourceError, match="uploaded with it"):
+        fetcher.fetch(url)
+
+
+def test_a_file_of_the_upload_directory_is_loaded(tmp_path: Path) -> None:
+    uploads = tmp_path / "uploads"
+    uploads.mkdir()
+    attachment = uploads / "attachment.bin"
+    attachment.write_bytes(b"an uploaded file")
+
+    response = PolicyUrlFetcher(allowed_file_root=uploads).fetch(attachment.as_uri())
+
+    assert response.read() == b"an uploaded file"
+
+
+def test_a_traversal_out_of_the_upload_directory_is_refused(tmp_path: Path) -> None:
+    uploads = tmp_path / "uploads"
+    uploads.mkdir()
+    secret = tmp_path / "secret.txt"
+    secret.write_text("top secret", encoding="utf-8")
+
+    fetcher = PolicyUrlFetcher(allowed_file_root=uploads)
+    url = f"{uploads.as_uri()}/../secret.txt"
+
+    with pytest.raises(ExternalResourceError, match="uploaded with it"):
+        fetcher.fetch(url)
+
+
+def test_an_internal_address_is_refused(local_server: str) -> None:
+    fetcher = PolicyUrlFetcher()
+
+    with pytest.raises(ExternalResourceError, match="not an address on the internet"):
+        fetcher.fetch(f"{local_server}/image.png")
+
+
+def test_an_internal_address_is_loaded_when_its_origin_is_allowed(monkeypatch: pytest.MonkeyPatch, local_server: str) -> None:
+    port = local_server.rsplit(":", 1)[1]
+    monkeypatch.setenv(ALLOWED_ORIGINS_VAR, f"127.0.0.1:{port}")
+
+    response = PolicyUrlFetcher().fetch(f"{local_server}/image.png")
+
+    assert response.status == 200
+    assert response.content_type == "image/png"
+
+
+def test_the_open_policy_loads_an_internal_address(monkeypatch: pytest.MonkeyPatch, local_server: str) -> None:
+    monkeypatch.setenv(POLICY_VAR, ResourcePolicy.ALLOW_ALL.value)
+
+    assert PolicyUrlFetcher().fetch(f"{local_server}/image.png").status == 200
+
+
+def test_the_allowlist_policy_refuses_an_address_which_is_not_listed(monkeypatch: pytest.MonkeyPatch, local_server: str) -> None:
+    monkeypatch.setenv(POLICY_VAR, ResourcePolicy.ALLOWLIST_ONLY.value)
+
+    fetcher = PolicyUrlFetcher()
+
+    with pytest.raises(ExternalResourceError, match=ALLOWED_ORIGINS_VAR):
+        fetcher.fetch(f"{local_server}/image.png")
+
+
+def test_a_body_which_is_not_a_resource_is_refused(monkeypatch: pytest.MonkeyPatch, local_server: str) -> None:
+    """This is the exfiltration case: a document asking for a body to be read back."""
+    monkeypatch.setenv(POLICY_VAR, ResourcePolicy.ALLOW_ALL.value)
+
+    fetcher = PolicyUrlFetcher()
+
+    with pytest.raises(ExternalResourceError, match="not an image, a font or a stylesheet"):
+        fetcher.fetch(f"{local_server}/secret.txt")
+
+
+def test_an_undeclared_body_is_sniffed(monkeypatch: pytest.MonkeyPatch, local_server: str) -> None:
+    monkeypatch.setenv(POLICY_VAR, ResourcePolicy.ALLOW_ALL.value)
+
+    assert PolicyUrlFetcher().fetch(f"{local_server}/undeclared").status == 200
+
+    fetcher = PolicyUrlFetcher()
+
+    with pytest.raises(ExternalResourceError, match="not an image or a font"):
+        fetcher.fetch(f"{local_server}/undeclared-text")
+
+
+def test_a_body_over_the_limit_is_refused(monkeypatch: pytest.MonkeyPatch, local_server: str) -> None:
+    monkeypatch.setenv(POLICY_VAR, ResourcePolicy.ALLOW_ALL.value)
+    monkeypatch.setenv(MAX_SIZE_MB_VAR, "1")
+
+    fetcher = PolicyUrlFetcher()
+
+    with pytest.raises(ExternalResourceError, match="larger than"):
+        fetcher.fetch(f"{local_server}/huge.png")
+
+
+def test_an_error_status_is_reported(monkeypatch: pytest.MonkeyPatch, local_server: str) -> None:
+    monkeypatch.setenv(POLICY_VAR, ResourcePolicy.ALLOW_ALL.value)
+
+    fetcher = PolicyUrlFetcher()
+
+    with pytest.raises(ExternalResourceError, match="answered 404"):
+        fetcher.fetch(f"{local_server}/missing")
+
+
+def test_a_proxied_host_has_to_be_listed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A proxy resolves the name itself, so such a request cannot be bound to a checked address."""
+    monkeypatch.setenv("http_proxy", "http://proxy.intranet:3128")
+
+    fetcher = PolicyUrlFetcher()
+
+    with pytest.raises(ExternalResourceError, match="through a proxy"):
+        fetcher.fetch("http://example.org/image.png")
+
+
+def test_a_redirect_is_followed(monkeypatch: pytest.MonkeyPatch, local_server: str) -> None:
+    monkeypatch.setenv(POLICY_VAR, ResourcePolicy.ALLOW_ALL.value)
+
+    response = PolicyUrlFetcher().fetch(f"{local_server}/redirect-to-image")
+
+    assert response.content_type == "image/png"
+
+
+def test_a_redirect_into_the_internal_network_is_refused(monkeypatch: pytest.MonkeyPatch, local_server: str) -> None:
+    """A hop is vetted like the address it came from, or a redirect would be the way around the policy."""
+    port = local_server.rsplit(":", 1)[1]
+    monkeypatch.setenv(ALLOWED_ORIGINS_VAR, f"127.0.0.1:{port}")
+
+    fetcher = PolicyUrlFetcher()
+
+    with pytest.raises(ExternalResourceError, match="not an address on the internet"):
+        fetcher.fetch(f"{local_server}/redirect-to-internal")
+
+
+def test_a_redirect_loop_ends(monkeypatch: pytest.MonkeyPatch, local_server: str) -> None:
+    monkeypatch.setenv(POLICY_VAR, ResourcePolicy.ALLOW_ALL.value)
+
+    fetcher = PolicyUrlFetcher()
+
+    with pytest.raises(ExternalResourceError, match="redirects more than"):
+        fetcher.fetch(f"{local_server}/redirect-loop")

--- a/tests/test_external_resources.py
+++ b/tests/test_external_resources.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import http.client
 import http.server
 import ssl
 import threading
@@ -417,3 +418,33 @@ def test_a_plain_connection_is_bound_to_the_vetted_address() -> None:
 
     assert connection.host == "93.184.216.34"
     assert connection.port == 80
+
+
+def test_an_https_resource_through_a_proxy_is_tunnelled_with_tls() -> None:
+    """A plain connection with a tunnel would put the request into it in the clear."""
+    connection = PolicyUrlFetcher()._through_proxy("http://proxy.intranet:3128", "https", "cdn.example", 443)
+
+    assert isinstance(connection, http.client.HTTPSConnection)
+    assert connection.host == "proxy.intranet"
+    assert connection.port == 3128
+    assert connection._tunnel_host == "cdn.example"
+
+
+def test_a_plain_resource_through_a_proxy_needs_no_tunnel() -> None:
+    connection = PolicyUrlFetcher()._through_proxy("http://proxy.intranet:3128", "http", "cdn.example", 80)
+
+    assert not isinstance(connection, http.client.HTTPSConnection)
+    assert connection._tunnel_host is None
+
+
+def test_the_next_vetted_address_is_tried(monkeypatch: pytest.MonkeyPatch, local_server: str) -> None:
+    """A dual stack host answers with an address this container may have no route to."""
+    monkeypatch.setenv(POLICY_VAR, ResourcePolicy.ALLOW_ALL.value)
+    monkeypatch.setenv("EXTERNAL_RESOURCES_TIMEOUT_SECONDS", "0.3")
+    port = int(local_server.rsplit(":", 1)[1])
+    # 192.0.2.1 is the documentation range: reserved, and no route leads there.
+    monkeypatch.setattr("app.external_resources.resolve", lambda host, port_number: ("192.0.2.1", "127.0.0.1"))
+
+    response = PolicyUrlFetcher().fetch(f"http://127.0.0.1:{port}/image.png")
+
+    assert response.content_type == "image/png"

--- a/tests/test_external_resources.py
+++ b/tests/test_external_resources.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import http.server
+import ssl
 import threading
 from collections.abc import Iterator
 from pathlib import Path
@@ -21,11 +22,21 @@ from app.external_resources import (
     get_max_size_bytes,
     get_policy,
     is_public_address,
+    tls_context,
 )
 
 POLICY_VARIABLES = (POLICY_VAR, ALLOWED_ORIGINS_VAR, MAX_SIZE_MB_VAR, "EXTERNAL_RESOURCES_TIMEOUT_SECONDS")
 
 PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 32
+
+REDIRECT_TARGETS = {
+    "/redirect-to-image": "/image.png",
+    "/redirect-to-internal": "http://169.254.169.254/latest/meta-data/",
+    "/redirect-loop": "/redirect-loop",
+    "/redirect-to-ftp": "ftp://example.org/font.ttf",
+    "/nested/redirect-relative": "../image.png",
+    "/redirect-query-only": "?ignored=1",
+}
 
 
 @pytest.fixture(autouse=True)
@@ -50,25 +61,23 @@ class _Handler(http.server.BaseHTTPRequestHandler):
             "/huge.png": (200, "image/png", PNG + b"\x00" * (2 * 1024 * 1024)),
             "/missing": (404, "text/plain", b"gone"),
         }
-        if self.path.startswith("/redirect"):
-            self._redirect()
+        path, _, query = self.path.partition("?")
+        if path == "/redirect-query-only" and query:
+            path = "/image.png"
+        elif path in REDIRECT_TARGETS:
+            self._redirect(path)
             return
-        status, content_type, body = routes.get(self.path, (404, "text/plain", b"gone"))
+        status, content_type, body = routes.get(path, (404, "text/plain", b"gone"))
         self.send_response(status)
         self.send_header("Content-Type", content_type)
         self.send_header("Content-Length", str(len(body)))
         self.end_headers()
         self.wfile.write(body)
 
-    def _redirect(self) -> None:
+    def _redirect(self, path: str) -> None:
         """Answer the redirects the tests follow."""
-        targets = {
-            "/redirect-to-image": "/image.png",
-            "/redirect-to-internal": "http://169.254.169.254/latest/meta-data/",
-            "/redirect-loop": "/redirect-loop",
-        }
         self.send_response(302)
-        self.send_header("Location", targets.get(self.path, "/image.png"))
+        self.send_header("Location", REDIRECT_TARGETS[path])
         self.send_header("Content-Length", "0")
         self.end_headers()
 
@@ -336,3 +345,51 @@ def test_a_redirect_loop_ends(monkeypatch: pytest.MonkeyPatch, local_server: str
 
     with pytest.raises(ExternalResourceError, match="redirects more than"):
         fetcher.fetch(f"{local_server}/redirect-loop")
+
+
+def test_a_redirect_to_another_scheme_is_refused(monkeypatch: pytest.MonkeyPatch, local_server: str) -> None:
+    """A hop names its own scheme, and it is gated like the address the document named."""
+    monkeypatch.setenv(POLICY_VAR, ResourcePolicy.ALLOW_ALL.value)
+    fetcher = PolicyUrlFetcher()
+
+    with pytest.raises(ExternalResourceError, match="scheme"):
+        fetcher.fetch(f"{local_server}/redirect-to-ftp")
+
+
+def test_a_relative_redirect_is_resolved_by_the_standard_rules(monkeypatch: pytest.MonkeyPatch, local_server: str) -> None:
+    monkeypatch.setenv(POLICY_VAR, ResourcePolicy.ALLOW_ALL.value)
+
+    response = PolicyUrlFetcher().fetch(f"{local_server}/nested/redirect-relative")
+
+    assert response.content_type == "image/png"
+
+
+def test_a_query_only_redirect_stays_on_the_same_path(monkeypatch: pytest.MonkeyPatch, local_server: str) -> None:
+    """Such a Location keeps the path, which a hand written resolver gets wrong."""
+    monkeypatch.setenv(POLICY_VAR, ResourcePolicy.ALLOW_ALL.value)
+
+    response = PolicyUrlFetcher().fetch(f"{local_server}/redirect-query-only")
+
+    assert response.content_type == "image/png"
+
+
+def test_a_percent_encoded_traversal_is_refused(tmp_path: Path) -> None:
+    """The check reads the path the loader reads, decoded."""
+    uploads = tmp_path / "uploads"
+    uploads.mkdir()
+    secret = tmp_path / "secret.txt"
+    secret.write_text("top secret", encoding="utf-8")
+
+    fetcher = PolicyUrlFetcher(allowed_file_root=uploads)
+    url = f"{uploads.as_uri()}/%2e%2e/secret.txt"
+
+    with pytest.raises(ExternalResourceError, match="uploaded with it"):
+        fetcher.fetch(url)
+
+
+def test_the_tls_context_refuses_the_old_protocol_versions() -> None:
+    context = tls_context()
+
+    assert context.minimum_version >= ssl.TLSVersion.TLSv1_2
+    assert context.verify_mode == ssl.CERT_REQUIRED
+    assert context.check_hostname is True


### PR DESCRIPTION
### Proposed changes

Closes #352.

A document names its own resources and WeasyPrint loaded whatever it named. `weasyprint.HTML(...)` was called without a `url_fetcher`, so the default one applied: http, https, ftp, file and data, redirects followed. A document reaching this service could therefore make it read an address of the network it sits in, and `<link rel="attachment">` returned the answer inside the produced PDF, which is not a blind request but a copy of the body.

`app/external_resources.py` is now the single gate every load passes:

- A name is resolved, **every** address it answers with is checked, and the request is bound to the address that was checked. A second lookup cannot answer differently, which is what closes DNS rebinding.
- Every redirect hop is checked again, at most five of them, so a redirect is not the way around the policy. There is a test for exactly that.
- The body is capped, and its kind has to be an image, a font or a stylesheet, by the declared type and, where a server declares none, by the content itself. This is what closes `rel="attachment"` as a way to read a body back.
- `data:` passes, it carries its own content. `file:` is refused, except under the temporary directory of the request, which is what keeps `/convert/html-with-attachments` working: that endpoint rewrites the hrefs to `file://` itself. `ftp:` and everything else are refused.
- A proxy resolves the name itself, so a proxied request cannot be bound to a checked address. It is made only for a host listed in the allowed origins, and the README states the consequence: where a proxy is configured for every destination, `BLOCK_INTERNAL` behaves as `ALLOWLIST_ONLY`.

`EXTERNAL_RESOURCES_POLICY` defaults to `BLOCK_INTERNAL`, matching SchweizerischeBundesbahnen/ch.sbb.polarion.extension.pdf-exporter#1006 so the pair is configured alike. **This is a behavior change**: a deployment which loads images from an internal host has to list it in `EXTERNAL_RESOURCES_ALLOWED_ORIGINS`. `ALLOW_ALL` restores the previous reach.

57 tests cover it: which addresses count as public (private ranges, link local including `169.254.169.254`, loopback wearing an IPv6 mapping, multicast), the origin syntax, the refused schemes, a traversal out of the attachments directory, redirects into the internal network, the size limit, the content kinds, and the proxy rule.

The sibling change for the pandoc service is SchweizerischeBundesbahnen/pandoc-service#224. The mechanism differs: WeasyPrint takes an injectable fetcher, pandoc does not, so it gets `--sandbox`.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
