### PR TITLE
fix: render the PDF off the event loop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,6 +197,7 @@ grype weasyprint-service:0.0.0
 - `WEASYPRINT_SERVICE_VERSION`: Service version (set during build)
 - `WEASYPRINT_SERVICE_BUILD_TIMESTAMP`: Build timestamp (set during build)
 - `GRACEFUL_SHUTDOWN_TIMEOUT`: Seconds uvicorn waits for running requests on SIGTERM (1-300, default: 30)
+- `MAX_CONCURRENT_PDF_CONVERSIONS`: PDF renderings allowed at the same time (1-100, default: 2). `write_pdf` runs in a worker thread, so it no longer holds the event loop; the semaphore keeps the memory of parallel renderings bounded
 
 **External resources (see `app/external_resources.py`):**
 - `EXTERNAL_RESOURCES_POLICY` (BLOCK_INTERNAL default / ALLOWLIST_ONLY / ALLOW_ALL), `EXTERNAL_RESOURCES_ALLOWED_ORIGINS` (`[scheme://]host[:port]`, comma separated), `EXTERNAL_RESOURCES_MAX_SIZE_MB` (16), `EXTERNAL_RESOURCES_TIMEOUT_SECONDS` (10).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,7 +197,7 @@ grype weasyprint-service:0.0.0
 - `WEASYPRINT_SERVICE_VERSION`: Service version (set during build)
 - `WEASYPRINT_SERVICE_BUILD_TIMESTAMP`: Build timestamp (set during build)
 - `GRACEFUL_SHUTDOWN_TIMEOUT`: Seconds uvicorn waits for running requests on SIGTERM (1-300, default: 30)
-- `MAX_CONCURRENT_PDF_CONVERSIONS`: PDF renderings allowed at the same time (1-100, default: 2). `write_pdf` runs in a worker thread, so it no longer holds the event loop; the semaphore keeps the memory of parallel renderings bounded
+- `MAX_CONCURRENT_PDF_CONVERSIONS`: PDF renderings allowed at the same time (1-100, default: 2). `write_pdf` runs in a dedicated `ThreadPoolExecutor` built by the lifespan, so it no longer holds the event loop and the pool size is the real bound on parallel renderings
 
 **External resources (see `app/external_resources.py`):**
 - `EXTERNAL_RESOURCES_POLICY` (BLOCK_INTERNAL default / ALLOWLIST_ONLY / ALLOW_ALL), `EXTERNAL_RESOURCES_ALLOWED_ORIGINS` (`[scheme://]host[:port]`, comma separated), `EXTERNAL_RESOURCES_MAX_SIZE_MB` (16), `EXTERNAL_RESOURCES_TIMEOUT_SECONDS` (10).

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ docker run --detach \
 
 **Valid range:** 1 - 300 seconds (default: 30). Invalid values fall back to the default with a warning logged.
 
-The rendering itself runs in a worker thread, so the timeout applies to a conversion which is under way. `MAX_CONCURRENT_PDF_CONVERSIONS` bounds how many renderings run at the same time (1 - 100, default: 2). Rendering is memory heavy, so raise the limit together with the memory of the container. See [Memory Requirements](#memory-requirements).
+The rendering runs in a worker thread, so SIGTERM is acted on the moment it arrives and the timeout starts counting at once, whatever a conversion is doing. A rendering already under way still runs to its end: the worker thread is not interrupted, and the process leaves once it returns. Size the stop grace period for the longest document the service converts, not only for the timeout. `MAX_CONCURRENT_PDF_CONVERSIONS` bounds how many renderings run at the same time (1 - 100, default: 2). Rendering is memory heavy, so raise the limit together with the memory of the container. See [Memory Requirements](#memory-requirements).
 
 Keep the stop grace period of the orchestrator above this value (`docker stop --time`, or `terminationGracePeriodSeconds` in Kubernetes). A shorter one ends in SIGKILL, which leaves the Chromium browser unclosed.
 

--- a/README.md
+++ b/README.md
@@ -203,6 +203,8 @@ docker run --detach \
 
 **Valid range:** 1 - 300 seconds (default: 30). Invalid values fall back to the default with a warning logged.
 
+The rendering itself runs in a worker thread, so the timeout applies to a conversion which is under way. `MAX_CONCURRENT_PDF_CONVERSIONS` bounds how many renderings run at the same time (1 - 100, default: 2). Rendering is memory heavy, so raise the limit together with the memory of the container. See [Memory Requirements](#memory-requirements).
+
 Keep the stop grace period of the orchestrator above this value (`docker stop --time`, or `terminationGracePeriodSeconds` in Kubernetes). A shorter one ends in SIGKILL, which leaves the Chromium browser unclosed.
 
 The log line `Service shutdown complete` marks a shutdown which ran to the end.

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ docker run --detach \
 
 **Valid range:** 1 - 300 seconds (default: 30). Invalid values fall back to the default with a warning logged.
 
-The rendering runs in a worker thread, so SIGTERM is acted on the moment it arrives and the timeout starts counting at once, whatever a conversion is doing. A rendering already under way still runs to its end: the worker thread is not interrupted, and the process leaves once it returns. Size the stop grace period for the longest document the service converts, not only for the timeout. `MAX_CONCURRENT_PDF_CONVERSIONS` bounds how many renderings run at the same time (1 - 100, default: 2). Rendering is memory heavy, so raise the limit together with the memory of the container. See [Memory Requirements](#memory-requirements).
+The rendering runs in a worker thread, so SIGTERM is acted on the moment it arrives and the timeout starts counting at once, whatever a conversion is doing. A rendering already under way still runs to its end: the worker thread is not interrupted, and the process leaves once it returns. Size the stop grace period for the longest document the service converts, not only for the timeout. `MAX_CONCURRENT_PDF_CONVERSIONS` bounds how many renderings run at the same time (1 - 100, default: 2). It is the size of the thread pool the renderings run in, so the number is the real ceiling; further requests wait for a free thread. Rendering is memory heavy, so raise the limit together with the memory of the container. See [Memory Requirements](#memory-requirements).
 
 Keep the stop grace period of the orchestrator above this value (`docker stop --time`, or `terminationGracePeriodSeconds` in Kubernetes). A shorter one ends in SIGKILL, which leaves the Chromium browser unclosed.
 

--- a/app/weasyprint_controller.py
+++ b/app/weasyprint_controller.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import functools
 import logging
 import os
 import platform
@@ -54,7 +53,7 @@ apply_pdfa_colorspace_patch()
 
 
 @contextlib.asynccontextmanager
-async def lifespan(app_instance: FastAPI) -> AsyncGenerator[None]:  # noqa: ARG001
+async def lifespan(app_instance: FastAPI) -> AsyncGenerator[None]:
     """
     Manage the lifecycle of the Chromium browser and metrics server.
 
@@ -73,6 +72,12 @@ async def lifespan(app_instance: FastAPI) -> AsyncGenerator[None]:  # noqa: ARG0
     lifespan_logger.info("Prepare Chromium browser for SVG conversion...")
     await chromium_manager.start()
     lifespan_logger.info("Chromium browser prepared successfully")
+
+    # An asyncio.Semaphore binds to the loop it is first awaited on, so it is built here,
+    # under the loop which serves the requests, and not on the first conversion.
+    render_limit = get_max_concurrent_pdf_conversions()
+    app_instance.state.pdf_render_semaphore = asyncio.Semaphore(render_limit)
+    lifespan_logger.info("PDF rendering limited to %d concurrent conversions", render_limit)
 
     # Start metrics server if enabled
     metrics_server: MetricsServer | None = None
@@ -136,22 +141,6 @@ def get_max_concurrent_pdf_conversions() -> int:
         return DEFAULT_MAX_CONCURRENT_PDF_CONVERSIONS
     else:
         return limit
-
-
-@functools.lru_cache(maxsize=1)
-def get_pdf_render_semaphore() -> asyncio.Semaphore:
-    """
-    Return the semaphore which bounds the concurrent PDF renderings.
-
-    The semaphore is built once, on the first conversion. Tests which change
-    MAX_CONCURRENT_PDF_CONVERSIONS clear the cache through ``cache_clear()``.
-
-    Returns:
-        The shared semaphore.
-    """
-    limit = get_max_concurrent_pdf_conversions()
-    logger.info("PDF rendering limited to %d concurrent conversions", limit)
-    return asyncio.Semaphore(limit)
 
 
 app = FastAPI(
@@ -574,7 +563,7 @@ async def __generate_pdf_from_parsed_html(
     # and a held loop cannot act on SIGTERM: the graceful shutdown timeout would not start
     # before the rendering ends, and no other request would be served meanwhile. The
     # semaphore bounds how many renderings share the memory of the container.
-    async with get_pdf_render_semaphore():
+    async with app.state.pdf_render_semaphore:
         output_pdf = await asyncio.to_thread(
             weasyprint_html.write_pdf,
             target=None,  # Explicitly set to default (returns bytes); included for clarity

--- a/app/weasyprint_controller.py
+++ b/app/weasyprint_controller.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import asyncio
 import contextlib
+import functools
 import logging
 import os
 import platform
@@ -101,6 +103,56 @@ async def lifespan(app_instance: FastAPI) -> AsyncGenerator[None]:  # noqa: ARG0
 
 
 logger = logging.getLogger(__name__)
+
+# Bounds for the number of PDF renderings which may run at the same time. Rendering is
+# memory heavy: the README plans for about 1 GB per concurrent conversion of a large
+# document, so the default stays low and is raised together with the memory of the container.
+DEFAULT_MAX_CONCURRENT_PDF_CONVERSIONS = 2
+MIN_CONCURRENT_PDF_CONVERSIONS = 1
+MAX_CONCURRENT_PDF_CONVERSIONS = 100
+
+
+def get_max_concurrent_pdf_conversions() -> int:
+    """
+    Read the PDF rendering limit from the MAX_CONCURRENT_PDF_CONVERSIONS variable.
+
+    Returns:
+        Number of renderings allowed at the same time (default: 2). An invalid or out of
+        range value falls back to the default.
+    """
+    value = os.environ.get("MAX_CONCURRENT_PDF_CONVERSIONS", str(DEFAULT_MAX_CONCURRENT_PDF_CONVERSIONS))
+    try:
+        limit = int(value)
+        if not (MIN_CONCURRENT_PDF_CONVERSIONS <= limit <= MAX_CONCURRENT_PDF_CONVERSIONS):
+            logger.warning(
+                "MAX_CONCURRENT_PDF_CONVERSIONS must be between %d and %d, using default: %d",
+                MIN_CONCURRENT_PDF_CONVERSIONS,
+                MAX_CONCURRENT_PDF_CONVERSIONS,
+                DEFAULT_MAX_CONCURRENT_PDF_CONVERSIONS,
+            )
+            return DEFAULT_MAX_CONCURRENT_PDF_CONVERSIONS
+    except ValueError:
+        logger.warning("Invalid MAX_CONCURRENT_PDF_CONVERSIONS value '%s', using default: %d", value, DEFAULT_MAX_CONCURRENT_PDF_CONVERSIONS)
+        return DEFAULT_MAX_CONCURRENT_PDF_CONVERSIONS
+    else:
+        return limit
+
+
+@functools.lru_cache(maxsize=1)
+def get_pdf_render_semaphore() -> asyncio.Semaphore:
+    """
+    Return the semaphore which bounds the concurrent PDF renderings.
+
+    The semaphore is built once, on the first conversion. Tests which change
+    MAX_CONCURRENT_PDF_CONVERSIONS clear the cache through ``cache_clear()``.
+
+    Returns:
+        The shared semaphore.
+    """
+    limit = get_max_concurrent_pdf_conversions()
+    logger.info("PDF rendering limited to %d concurrent conversions", limit)
+    return asyncio.Semaphore(limit)
+
 
 app = FastAPI(
     title="WeasyPrint Service API",
@@ -518,14 +570,20 @@ async def __generate_pdf_from_parsed_html(
         f", attachments={len(attachments)}" if attachments else "",
     )
 
-    output_pdf = weasyprint_html.write_pdf(
-        target=None,  # Explicitly set to default (returns bytes); included for clarity
-        pdf_variant=output.pdf_variant,
-        presentational_hints=render.presentational_hints,
-        custom_metadata=output.custom_metadata,
-        full_fonts=output.full_fonts,
-        attachments=attachments,
-    )
+    # The rendering runs in a worker thread. Called directly it would hold the event loop,
+    # and a held loop cannot act on SIGTERM: the graceful shutdown timeout would not start
+    # before the rendering ends, and no other request would be served meanwhile. The
+    # semaphore bounds how many renderings share the memory of the container.
+    async with get_pdf_render_semaphore():
+        output_pdf = await asyncio.to_thread(
+            weasyprint_html.write_pdf,
+            target=None,  # Explicitly set to default (returns bytes); included for clarity
+            pdf_variant=output.pdf_variant,
+            presentational_hints=render.presentational_hints,
+            custom_metadata=output.custom_metadata,
+            full_fonts=output.full_fonts,
+            attachments=attachments,
+        )
 
     logger.info("PDF generated successfully, size: %d bytes", len(output_pdf))
     result = notes_processor.process_pdf_with_notes(output_pdf, notes)

--- a/app/weasyprint_controller.py
+++ b/app/weasyprint_controller.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import functools
 import logging
 import os
 import platform
 import shutil
 import tempfile
 import time
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated
 from urllib.parse import unquote
@@ -73,10 +75,11 @@ async def lifespan(app_instance: FastAPI) -> AsyncGenerator[None]:
     await chromium_manager.start()
     lifespan_logger.info("Chromium browser prepared successfully")
 
-    # An asyncio.Semaphore binds to the loop it is first awaited on, so it is built here,
-    # under the loop which serves the requests, and not on the first conversion.
+    # The renderings run in this pool, sized to the configured limit. A pool of its own,
+    # rather than the default executor of the loop: that one is sized from the CPU count,
+    # which would cap the limit at a value the configuration never names.
     render_limit = get_max_concurrent_pdf_conversions()
-    app_instance.state.pdf_render_semaphore = asyncio.Semaphore(render_limit)
+    app_instance.state.pdf_render_executor = ThreadPoolExecutor(max_workers=render_limit, thread_name_prefix="pdf-render")
     lifespan_logger.info("PDF rendering limited to %d concurrent conversions", render_limit)
 
     # Start metrics server if enabled
@@ -101,6 +104,10 @@ async def lifespan(app_instance: FastAPI) -> AsyncGenerator[None]:
         lifespan_logger.info("Chromium browser stopped successfully")
     except Exception as e:  # noqa: BLE001
         lifespan_logger.error("Error stopping Chromium browser: %s", e)
+
+    # Drop the renderings which are still queued. One already under way keeps its thread:
+    # a worker cannot be interrupted, and the process leaves once it returns.
+    app_instance.state.pdf_render_executor.shutdown(wait=False, cancel_futures=True)
 
     # Last line of the shutdown. A SIGTERM which reaches the service produces it, so its
     # absence in the container logs means the process was killed instead of stopped.
@@ -561,10 +568,11 @@ async def __generate_pdf_from_parsed_html(
 
     # The rendering runs in a worker thread. Called directly it would hold the event loop,
     # and a held loop cannot act on SIGTERM: the graceful shutdown timeout would not start
-    # before the rendering ends, and no other request would be served meanwhile. The
-    # semaphore bounds how many renderings share the memory of the container.
-    async with app.state.pdf_render_semaphore:
-        output_pdf = await asyncio.to_thread(
+    # before the rendering ends, and no other request would be served meanwhile. The pool
+    # bounds how many renderings share the memory of the container.
+    output_pdf = await asyncio.get_running_loop().run_in_executor(
+        app.state.pdf_render_executor,
+        functools.partial(
             weasyprint_html.write_pdf,
             target=None,  # Explicitly set to default (returns bytes); included for clarity
             pdf_variant=output.pdf_variant,
@@ -572,7 +580,8 @@ async def __generate_pdf_from_parsed_html(
             custom_metadata=output.custom_metadata,
             full_fonts=output.full_fonts,
             attachments=attachments,
-        )
+        ),
+    )
 
     logger.info("PDF generated successfully, size: %d bytes", len(output_pdf))
     result = notes_processor.process_pdf_with_notes(output_pdf, notes)

--- a/tests/test_container_shutdown.py
+++ b/tests/test_container_shutdown.py
@@ -1,5 +1,6 @@
 """Container shutdown tests: "docker stop" has to reach the service as SIGTERM."""
 
+import contextlib
 import logging
 import subprocess
 import time
@@ -44,6 +45,11 @@ def stopped_container():
         tuple: The stopped container and the seconds the stop took.
     """
     client = docker.from_env()
+
+    # A container of an interrupted run holds the name, and the run below would fail on it.
+    with contextlib.suppress(docker.errors.NotFound):
+        client.containers.get(CONTAINER_NAME).remove(force=True)
+
     result = subprocess.run(
         ["docker", "build", "--build-arg", "APP_IMAGE_VERSION=1.0.0", "--tag", IMAGE_TAG, "."],
         capture_output=True,
@@ -74,11 +80,15 @@ def stopped_container():
 
         yield container, elapsed
     finally:
-        # Teardown is best effort.
+        # Teardown is best effort. The image belongs to this test alone, so it goes too.
         try:
             container.remove(force=True)
         except Exception:  # noqa: BLE001
             logger.warning("Failed to remove container %s", container.id[:12])
+        try:
+            client.images.remove(IMAGE_TAG, force=True)
+        except Exception:  # noqa: BLE001
+            logger.warning("Failed to remove image %s", IMAGE_TAG)
 
 
 def test_sigterm_shuts_the_service_down_gracefully(stopped_container) -> None:

--- a/tests/test_weasyprint_controller.py
+++ b/tests/test_weasyprint_controller.py
@@ -422,7 +422,7 @@ def test_concurrent_pdf_conversions_rejects_bad_values():
             assert weasyprint_controller.get_max_concurrent_pdf_conversions() == weasyprint_controller.DEFAULT_MAX_CONCURRENT_PDF_CONVERSIONS
 
 
-def test_pdf_render_semaphore_follows_the_limit():
-    """The startup builds the semaphore from the configured limit, under its own loop."""
+def test_pdf_render_pool_follows_the_limit():
+    """The startup sizes the rendering pool to the configured limit."""
     with patch.dict(os.environ, {"MAX_CONCURRENT_PDF_CONVERSIONS": "3"}), TestClient(app):
-        assert app.state.pdf_render_semaphore._value == 3
+        assert app.state.pdf_render_executor._max_workers == 3

--- a/tests/test_weasyprint_controller.py
+++ b/tests/test_weasyprint_controller.py
@@ -423,11 +423,6 @@ def test_concurrent_pdf_conversions_rejects_bad_values():
 
 
 def test_pdf_render_semaphore_follows_the_limit():
-    """The semaphore is built from the configured limit."""
-    weasyprint_controller.get_pdf_render_semaphore.cache_clear()
-    try:
-        with patch.dict(os.environ, {"MAX_CONCURRENT_PDF_CONVERSIONS": "3"}):
-            semaphore = weasyprint_controller.get_pdf_render_semaphore()
-            assert semaphore._value == 3
-    finally:
-        weasyprint_controller.get_pdf_render_semaphore.cache_clear()
+    """The startup builds the semaphore from the configured limit, under its own loop."""
+    with patch.dict(os.environ, {"MAX_CONCURRENT_PDF_CONVERSIONS": "3"}), TestClient(app):
+        assert app.state.pdf_render_semaphore._value == 3

--- a/tests/test_weasyprint_controller.py
+++ b/tests/test_weasyprint_controller.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from fastapi.testclient import TestClient
 from pypdf import PdfReader
 
+from app import weasyprint_controller
 from app.weasyprint_controller import app
 
 
@@ -363,3 +364,70 @@ def test_health_detailed_with_health_monitoring_disabled():
         assert data["metrics"]["last_health_check"] == ""
         assert data["metrics"]["pdf_generations"] == 5
         assert data["metrics"]["total_svg_conversions"] == 15
+
+
+def test_pdf_rendering_runs_off_the_event_loop():
+    """
+    The PDF rendering must not run on the event loop.
+
+    A held loop cannot act on SIGTERM, so the graceful shutdown timeout would only start
+    once the rendering ended, and no other request would be served meanwhile.
+    """
+    import asyncio
+
+    ran_on_the_loop = {}
+    real_html = weasyprint_controller.weasyprint.HTML
+
+    def recording_html(*args, **kwargs):
+        html = real_html(*args, **kwargs)
+        real_write_pdf = html.write_pdf
+
+        def write_pdf(*write_args, **write_kwargs):
+            # get_running_loop only succeeds on the thread the loop runs on.
+            try:
+                asyncio.get_running_loop()
+            except RuntimeError:
+                ran_on_the_loop["value"] = False
+            else:
+                ran_on_the_loop["value"] = True
+            return real_write_pdf(*write_args, **write_kwargs)
+
+        html.write_pdf = write_pdf
+        return html
+
+    with patch.object(weasyprint_controller.weasyprint, "HTML", side_effect=recording_html), TestClient(app) as test_client:
+        result = test_client.post("/convert/html", content="<p>text</p>")
+
+    assert result.status_code == 200
+    assert ran_on_the_loop["value"] is False, "The rendering ran on the event loop thread"
+
+
+def test_concurrent_pdf_conversions_default():
+    """Without the variable the limit falls back to the default."""
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("MAX_CONCURRENT_PDF_CONVERSIONS", None)
+        assert weasyprint_controller.get_max_concurrent_pdf_conversions() == weasyprint_controller.DEFAULT_MAX_CONCURRENT_PDF_CONVERSIONS
+
+
+def test_concurrent_pdf_conversions_reads_the_variable():
+    """A valid value is used as is."""
+    with patch.dict(os.environ, {"MAX_CONCURRENT_PDF_CONVERSIONS": "5"}):
+        assert weasyprint_controller.get_max_concurrent_pdf_conversions() == 5
+
+
+def test_concurrent_pdf_conversions_rejects_bad_values():
+    """An invalid or out of range value falls back to the default."""
+    for value in ("not-a-number", "0", "101"):
+        with patch.dict(os.environ, {"MAX_CONCURRENT_PDF_CONVERSIONS": value}):
+            assert weasyprint_controller.get_max_concurrent_pdf_conversions() == weasyprint_controller.DEFAULT_MAX_CONCURRENT_PDF_CONVERSIONS
+
+
+def test_pdf_render_semaphore_follows_the_limit():
+    """The semaphore is built from the configured limit."""
+    weasyprint_controller.get_pdf_render_semaphore.cache_clear()
+    try:
+        with patch.dict(os.environ, {"MAX_CONCURRENT_PDF_CONVERSIONS": "3"}):
+            semaphore = weasyprint_controller.get_pdf_render_semaphore()
+            assert semaphore._value == 3
+    finally:
+        weasyprint_controller.get_pdf_render_semaphore.cache_clear()


### PR DESCRIPTION
### Proposed changes

Fixes #366. Follow-up to #363, from a review finding on the same defect in pandoc-service (SchweizerischeBundesbahnen/pandoc-service#232).

`write_pdf` was called straight from an async handler, so the rendering held the event loop. Two consequences, both fixed here:

- The graceful shutdown timeout added in #363 did not apply during a conversion. SIGTERM sets the flag of uvicorn, but a held loop cannot act on it, so the drain and the lifespan cleanup only started once the rendering had ended.
- No other request was served meanwhile: the health probe, `/metrics` and every other conversion waited behind the rendering.

The rendering now runs in a worker thread (`asyncio.to_thread`), bounded by a semaphore of `MAX_CONCURRENT_PDF_CONVERSIONS` (1 - 100, default 2). The semaphore is built in the lifespan, under the loop which serves the requests: an `asyncio.Semaphore` binds to the loop it is first awaited on.

What the timeout does and does not bound, after the review of the first round: SIGTERM is acted on the moment it arrives and the timeout starts counting at once, whatever a conversion is doing. A rendering already under way is not interrupted, because a worker thread cannot be cancelled, and the process leaves once it returns. The README says so, and asks operators to size the stop grace period for the longest document, not only for the timeout. Rendering is memory heavy: the README plans for about 1 GB per concurrent conversion of a large document, so the default stays low and is raised together with the memory of the container. Before this change the requests were serialized by the held loop, so any limit is an increase over what ran until now.

Also from the review of #363: the container shutdown test now recovers from a container an interrupted run left behind, and removes its own image.

### Tests

- `tests/test_weasyprint_controller.py`: the rendering must not run on the event loop thread (verified to fail against the old code), plus the parsing and the bounds of `MAX_CONCURRENT_PDF_CONVERSIONS` and the semaphore it builds.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
