### PR TITLE
fix: stop crashing on a running element in a float

### DIFF
--- a/app/weasyprint_controller.py
+++ b/app/weasyprint_controller.py
@@ -47,11 +47,17 @@ from app.schemas import ChromiumMetricsSchema, HealthSchema, VersionSchema
 from app.svg_processor import SvgProcessor
 from app.vsdx_processor import VsdxProcessor
 from app.weasyprint_pdfa_patch import apply_pdfa_colorspace_patch
+from app.weasyprint_running_width_patch import apply_running_width_patch
 
 # WeasyPrint 69.0 writes PDF/A gradient colour spaces as a bare ``/srgb`` name that
 # pdfium/MuPDF and PDFBox cannot resolve, which drops gradients. Apply the fix at
 # import time so every conversion path is covered. See app/weasyprint_pdfa_patch.py.
 apply_pdfa_colorspace_patch()
+
+# WeasyPrint crashes on a block-level ``position: running()`` element that holds text
+# inside a shrink-to-fit box (float, inline-block, absolute, table cell, flex item).
+# Apply the fix at import time as well. See app/weasyprint_running_width_patch.py.
+apply_running_width_patch()
 
 
 @contextlib.asynccontextmanager

--- a/app/weasyprint_running_width_patch.py
+++ b/app/weasyprint_running_width_patch.py
@@ -1,0 +1,117 @@
+"""Work around a WeasyPrint crash on a running element inside a shrink-to-fit box.
+
+Background
+----------
+A block-level ``position: running(name)`` element that holds text raises
+``TypeError: min-content width for TextBox not handled yet`` when it sits inside
+an intrinsic-width (shrink-to-fit) container: a float, an ``inline-block``, an
+absolutely positioned box, an auto-layout table cell or a flex item.
+
+Two WeasyPrint details combine into the crash:
+
+1. ``formatting_structure/build.py`` returns early from ``inline_in_block()`` for
+   a running box, so its text is never wrapped in a ``LineBox`` and a bare
+   ``TextBox`` survives as a direct child of the block.
+2. ``layout/preferred.py`` filters only absolutely positioned children out of the
+   intrinsic-width walk, so it recurses into the running box, reaches that
+   ``TextBox`` and has no branch for it.
+
+The ``@page { @top-center { content: element(name) } }`` rule that normally
+consumes the running element is not required to trigger the crash.
+
+Fix
+---
+A running element is removed from the normal flow (see ``Box.is_in_normal_flow``),
+so it must not contribute to the intrinsic width of its container at all. Return
+zero for a running box at every entry point of the intrinsic-width calculation.
+
+This is a temporary shim. ``apply_running_width_patch`` is idempotent and, if a
+future WeasyPrint no longer exposes the patched internals, degrades to a no-op
+without ever breaking PDF generation. Remove it once fixed upstream.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from weasyprint.layout import flex as weasyprint_flex  # type: ignore[import-untyped]
+from weasyprint.layout import grid as weasyprint_grid  # type: ignore[import-untyped]
+from weasyprint.layout import page as weasyprint_page  # type: ignore[import-untyped]
+from weasyprint.layout import preferred as weasyprint_preferred  # type: ignore[import-untyped]
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+logger = logging.getLogger(__name__)
+
+_PATCH_FLAG = "_running_element_width_patch"
+
+# Intrinsic-width entry points of weasyprint.layout.preferred, with the value a
+# running box must contribute. The table-cell helpers are patched too because
+# weasyprint.layout.table reaches them without going through min_content_width.
+_PATCHED_FUNCTIONS: dict[str, Any] = {
+    "min_content_width": 0,
+    "max_content_width": 0,
+    "table_cell_min_content_width": 0,
+    "table_cell_min_max_content_width": (0, 0),
+}
+
+# Modules that bind min_content_width/max_content_width by name at import time.
+# Patching weasyprint.layout.preferred alone would leave their copies unpatched.
+_MIRROR_MODULES = (weasyprint_flex, weasyprint_grid, weasyprint_page)
+_MIRRORED_NAMES = ("min_content_width", "max_content_width")
+
+
+def _zero_for_running(function: Callable[..., Any], empty: Any) -> Callable[..., Any]:
+    """Wrap an intrinsic-width function so a running box contributes ``empty``."""
+
+    def wrapper(context: Any, box: Any, *args: Any, **kwargs: Any) -> Any:
+        try:
+            is_running = box.is_running()
+        except Exception:
+            logger.warning("Running-element width patch skipped for one box", exc_info=True)
+            is_running = False
+        if is_running:
+            return empty
+        return function(context, box, *args, **kwargs)
+
+    setattr(wrapper, _PATCH_FLAG, True)
+    return wrapper
+
+
+def apply_running_width_patch() -> bool:
+    """Monkey-patch WeasyPrint so a running element has no intrinsic width.
+
+    Returns ``True`` when the patch is applied, ``False`` when it was already
+    applied or the WeasyPrint internals could not be located.
+    """
+    if is_applied():
+        return False
+
+    originals: dict[str, Any] = {}
+    missing: list[str] = []
+    for name in _PATCHED_FUNCTIONS:
+        function = getattr(weasyprint_preferred, name, None)
+        if function is None:
+            missing.append(name)
+        else:
+            originals[name] = function
+    if missing:
+        logger.warning("WeasyPrint intrinsic-width functions not found (%s); running-element patch skipped", ", ".join(missing))
+        return False
+
+    for name, empty in _PATCHED_FUNCTIONS.items():
+        setattr(weasyprint_preferred, name, _zero_for_running(originals[name], empty))
+    for module in _MIRROR_MODULES:
+        for name in _MIRRORED_NAMES:
+            if hasattr(module, name):
+                setattr(module, name, getattr(weasyprint_preferred, name))
+
+    logger.info("Applied WeasyPrint running-element intrinsic-width patch (running boxes no longer contribute a width)")
+    return True
+
+
+def is_applied() -> bool:
+    """Return whether the running-element intrinsic-width patch is installed."""
+    return all(getattr(getattr(weasyprint_preferred, name, None), _PATCH_FLAG, False) for name in _PATCHED_FUNCTIONS)

--- a/app/weasyprint_running_width_patch.py
+++ b/app/weasyprint_running_width_patch.py
@@ -32,13 +32,9 @@ without ever breaking PDF generation. Remove it once fixed upstream.
 
 from __future__ import annotations
 
+import importlib
 import logging
 from typing import TYPE_CHECKING, Any
-
-from weasyprint.layout import flex as weasyprint_flex  # type: ignore[import-untyped]
-from weasyprint.layout import grid as weasyprint_grid  # type: ignore[import-untyped]
-from weasyprint.layout import page as weasyprint_page  # type: ignore[import-untyped]
-from weasyprint.layout import preferred as weasyprint_preferred  # type: ignore[import-untyped]
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -46,6 +42,23 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _PATCH_FLAG = "_running_element_width_patch"
+
+
+def _layout_module(name: str) -> Any | None:
+    """Import a private WeasyPrint layout module, or return ``None``.
+
+    These modules are internal to WeasyPrint. Importing them by hand keeps the
+    no-op promise of this shim honest: a future WeasyPrint that moves or drops
+    one must not stop the service from starting.
+    """
+    try:
+        return importlib.import_module(f"weasyprint.layout.{name}")
+    except ImportError:
+        logger.warning("WeasyPrint layout module %r not found; running-element patch degraded", name, exc_info=True)
+        return None
+
+
+weasyprint_preferred = _layout_module("preferred")
 
 # Intrinsic-width entry points of weasyprint.layout.preferred, with the value a
 # running box must contribute. The table-cell helpers are patched too because
@@ -59,18 +72,24 @@ _PATCHED_FUNCTIONS: dict[str, Any] = {
 
 # Modules that bind min_content_width/max_content_width by name at import time.
 # Patching weasyprint.layout.preferred alone would leave their copies unpatched.
-_MIRROR_MODULES = (weasyprint_flex, weasyprint_grid, weasyprint_page)
+_MIRROR_MODULES = tuple(module for module in (_layout_module("flex"), _layout_module("grid"), _layout_module("page")) if module is not None)
 _MIRRORED_NAMES = ("min_content_width", "max_content_width")
 
 
 def _zero_for_running(function: Callable[..., Any], empty: Any) -> Callable[..., Any]:
     """Wrap an intrinsic-width function so a running box contributes ``empty``."""
+    warned = False
 
     def wrapper(context: Any, box: Any, *args: Any, **kwargs: Any) -> Any:
+        nonlocal warned
         try:
             is_running = box.is_running()
         except Exception:
-            logger.warning("Running-element width patch skipped for one box", exc_info=True)
+            # This branch means the box API changed, so every box takes it. Warn once
+            # per wrapper instead of once per box, or one conversion floods the log.
+            if not warned:
+                warned = True
+                logger.warning("Running-element width patch skipped for one box; suppressing further warnings", exc_info=True)
             is_running = False
         if is_running:
             return empty
@@ -86,7 +105,7 @@ def apply_running_width_patch() -> bool:
     Returns ``True`` when the patch is applied, ``False`` when it was already
     applied or the WeasyPrint internals could not be located.
     """
-    if is_applied():
+    if weasyprint_preferred is None or is_applied():
         return False
 
     originals: dict[str, Any] = {}

--- a/repro/README.md
+++ b/repro/README.md
@@ -1,13 +1,13 @@
-# Repro: WeasyPrint 69.0 drops `linear-gradient` backgrounds under PDF/A
+# WeasyPrint bug reproductions
 
-A CSS `linear-gradient` background renders fine in **WeasyPrint 68.1** but
-**disappears in WeasyPrint 69.0** when the PDF is written as **PDF/A**.
+Minimal, service-free reproductions of the upstream WeasyPrint bugs that `app/` works
+around. Each one runs the same monkey patch the service applies, so a WeasyPrint bump can
+be checked against them before the workaround is kept or dropped.
 
-* `gradient.html` — minimal input: a single `<div>` with a `linear-gradient` background.
-* `repro.py` — renders it with `write_pdf(pdf_variant="pdf/a-2b")`, reports the gradient
-  shading's colour space and whether the gradient actually paints, and saves the PDF.
-  Pass `--patch` to apply the service workaround (`app/weasyprint_pdfa_patch.py`).
-* `run.sh` — runs `repro.py` with WeasyPrint 68.1, 69.0, and 69.0 + the fix, via `uv`.
+| Repro | Bug | Service workaround |
+|---|---|---|
+| [PDF/A gradients](#1-weasyprint-690-drops-linear-gradient-backgrounds-under-pdfa) | `linear-gradient` disappears from PDF/A output | `app/weasyprint_pdfa_patch.py` |
+| [Running elements](#2-weasyprint-crashes-on-a-running-element-in-a-shrink-to-fit-box) | `TypeError: min-content width for TextBox not handled yet` | `app/weasyprint_running_width_patch.py` |
 
 ## Run (native, no Docker)
 
@@ -17,12 +17,12 @@ Prerequisites: [`uv`](https://docs.astral.sh/uv/) and WeasyPrint's system librar
 # macOS (one-time): install the native libs WeasyPrint needs
 brew install pango          # pulls glib/gobject, cairo, harfbuzz, fontconfig, …
 
-./run.sh
+./run.sh                    # runs both reproductions
 ```
 
 On Linux: `apt-get install libpango-1.0-0 libpangocairo-1.0-0`, then `./run.sh`.
 
-Run a single version manually (macOS needs `DYLD_FALLBACK_LIBRARY_PATH` so dlopen finds
+Run a single repro manually (macOS needs `DYLD_FALLBACK_LIBRARY_PATH` so dlopen finds
 Homebrew's libs):
 
 ```bash
@@ -30,7 +30,19 @@ DYLD_FALLBACK_LIBRARY_PATH="$(brew --prefix)/lib" \
   uv run --with 'weasyprint==69.0' --with pymupdf repro.py
 ```
 
-## Expected output
+---
+
+## 1. WeasyPrint 69.0 drops `linear-gradient` backgrounds under PDF/A
+
+A CSS `linear-gradient` background renders fine in **WeasyPrint 68.1** but
+**disappears in WeasyPrint 69.0** when the PDF is written as **PDF/A**.
+
+* `gradient.html` — minimal input: a single `<div>` with a `linear-gradient` background.
+* `repro.py` — renders it with `write_pdf(pdf_variant="pdf/a-2b")`, reports the gradient
+  shading's colour space and whether the gradient actually paints, and saves the PDF.
+  Pass `--patch` to apply the service workaround (`app/weasyprint_pdfa_patch.py`).
+
+### Expected output
 
 Each run reports every supported PDF/A variant. On WeasyPrint 69.0:
 
@@ -50,7 +62,7 @@ weasyprint 69.0+patch
 On WeasyPrint 68.1 every variant renders (`ColorSpace = /DeviceRGB`). A representative
 `gradient_pdf-a-2b_*.pdf` is saved per run for visual inspection.
 
-## Validating on a future WeasyPrint version
+### Validating on a future WeasyPrint version
 
 When bumping WeasyPrint, run the repro on the new version with and without the fix:
 
@@ -64,7 +76,7 @@ uv run --with 'weasyprint==<new>' --with pymupdf repro.py --patch    # with the 
 * with `--patch` **BLANK** → WeasyPrint internals changed; the patch needs updating
   (it fails safe — never breaks PDF generation — but no longer fixes the gradient).
 
-## Root cause
+### Root cause
 
 WeasyPrint 69.0 reworked PDF colour management (output intents / ICC profiles —
 Kozea/WeasyPrint #2631, #2778, #2785, #2788). For PDF/A it now expresses colours in a
@@ -73,3 +85,75 @@ Kozea/WeasyPrint #2631, #2778, #2785, #2788). For PDF/A it now expresses colours
 — pdfium / MuPDF (PyMuPDF), Apache PDFBox — do not resolve the named `/srgb` colour space
 for shadings (`unknown colorspace: srgb`), so the gradient is not painted. WeasyPrint 68.1
 used `/DeviceRGB` directly, which every renderer handles.
+
+---
+
+## 2. WeasyPrint crashes on a running element in a shrink-to-fit box
+
+A block-level `position: running(name)` element holding text makes WeasyPrint raise
+`TypeError: min-content width for TextBox not handled yet` when it sits inside an
+intrinsic-width container. Reproduced on **WeasyPrint 68.1 and 69.0**.
+
+* `running_element.html` — minimal input: a running element inside a `float: left` box.
+* `repro_running_element.py` — renders that running element under every intrinsic-width
+  wrapper and reports which ones convert. Pass `--patch` to apply the service workaround
+  (`app/weasyprint_running_width_patch.py`).
+
+Three ingredients are required. Remove any one and the error disappears.
+
+1. `position: running(name)` on a **block-level** element.
+2. **Text** inside it. An empty running element is fine, and so is `position: running()`
+   on an inline `<span>`.
+3. An **intrinsic-width (shrink-to-fit) wrapper**: `float`, `display: inline-block`,
+   `position: absolute`, an auto-layout `<td>`, or a flex item.
+
+The `@page { @top-center { content: element(name) } }` rule that normally consumes the
+running element is **not** required. `width: min-content` on the wrapper does not trigger
+it either.
+
+### Expected output
+
+```
+weasyprint 69.0
+  float: left                      ->  CRASHES: TypeError: min-content width for TextBox not handled yet
+  ...                                           (every wrapper crashes)
+  flex item                        ->  CRASHES: TypeError: min-content width for TextBox not handled yet
+
+weasyprint 69.0+patch
+  float: left                      ->  CONVERTS ok (4041 bytes, running text in top margin box)
+  ...                                           (every wrapper converts)
+  flex item                        ->  CONVERTS ok (4039 bytes, running text in top margin box)
+```
+
+`running text in top margin box` confirms the patch costs the running element nothing: its
+content still moves into the `@top-center` margin box.
+
+### Validating on a future WeasyPrint version
+
+```bash
+uv run --with 'weasyprint==<new>' --with pymupdf repro_running_element.py           # without
+uv run --with 'weasyprint==<new>' --with pymupdf repro_running_element.py --patch   # with
+```
+
+* without `--patch` every wrapper **CONVERTS** → upstream fixed it; the service patch can
+  be removed.
+* without `--patch` **CRASHES** but with `--patch` **CONVERTS** → keep the patch.
+* with `--patch` **CRASHES** → WeasyPrint internals changed; the patch needs updating
+  (it fails safe — never breaks PDF generation — but no longer prevents the crash).
+
+### Root cause
+
+Two WeasyPrint details combine. `formatting_structure/build.py` returns early from
+`inline_in_block()` for a running box, so its text is never wrapped in a `LineBox` and a
+bare `TextBox` survives as a direct child of the block. `layout/preferred.py` then filters
+only absolutely positioned children out of the intrinsic-width walk, recurses into the
+running box, reaches that `TextBox` and has no branch for it.
+
+A running element is removed from the normal flow (`Box.is_in_normal_flow()` says so), so
+it must not contribute to its container's intrinsic width at all. The patch returns zero
+for a running box at every entry point of the intrinsic-width calculation.
+
+Two exotic cases stay broken with the patch, because table and grid layout keep a running
+child in the flow and then fail differently (`TypeError: Layout for TextBox not handled
+yet`): a `<td>` that is itself the running element, and a running element that is itself a
+grid item. Neither produces the error this repro is about.

--- a/repro/repro_running_element.py
+++ b/repro/repro_running_element.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""
+Minimal reproduction + validation: WeasyPrint crashes on a running element that
+sits inside a shrink-to-fit box.
+
+A block-level ``position: running(name)`` element holding text raises
+``TypeError: min-content width for TextBox not handled yet`` whenever an
+intrinsic-width container asks for its width. WeasyPrint never wraps a running
+element's text in a line box (``inline_in_block`` returns early for a running
+box), and the intrinsic-width walk in ``layout/preferred.py`` filters out only
+absolutely positioned children, so it recurses into the running box and reaches
+a bare ``TextBox`` it has no branch for.
+
+The script renders the same running element under every intrinsic-width wrapper
+and reports which ones convert. Run once per WeasyPrint version (``uv`` makes
+this a one-liner; the WeasyPrint system libraries - pango/cairo/... - must be
+present):
+
+    uv run --with 'weasyprint==69.0' repro_running_element.py
+    uv run --with 'weasyprint==69.0' repro_running_element.py --patch
+
+``--patch`` applies the weasyprint-service workaround
+(app/weasyprint_running_width_patch.py). Use it to validate, on any future
+WeasyPrint, that the service fix still converts these documents - and run
+without it to check whether upstream has fixed the bug.
+
+Expected on 69.0: every wrapper CRASHES without ``--patch``, every wrapper
+CONVERTS with it.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+import weasyprint
+
+# The wrapper style that replaces "float: left" in running_element.html. Each one
+# puts the running element into an intrinsic-width (shrink-to-fit) context.
+WRAPPER_STYLES = [
+    "float: left",
+    "display: inline-block",
+    "position: absolute",
+]
+
+# The markup of the wrapper in running_element.html, and the two wrappers that need
+# their own markup rather than a style: an auto-layout table cell, and a flex item
+# (the running element must be *inside* the item, not be the item itself).
+WRAPPER_OPEN = '<div style="float: left">'
+WRAPPER_CLOSE = "</div>\n    BODYTEXT"
+MARKUP_WRAPPERS = {
+    "table cell": ("<table><tr><td>", "</td></tr></table>\n    BODYTEXT"),
+    "flex item": ('<div style="display: flex; width: min-content"><div>', "</div></div>\n    BODYTEXT"),
+}
+
+# The page margin in running_element.html. Text above it is inside the top margin box.
+PAGE_MARGIN_PX = 40
+
+patched = "--patch" in sys.argv
+if patched:
+    # Apply the weasyprint-service fix from its single source of truth.
+    sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
+    from app.weasyprint_running_width_patch import apply_running_width_patch
+
+    apply_running_width_patch()
+
+template = pathlib.Path(__file__).with_name("running_element.html").read_text()
+
+
+def documents() -> dict[str, str]:
+    """Return one document per intrinsic-width wrapper, keyed by wrapper name."""
+    result = {style: template.replace("float: left", style) for style in WRAPPER_STYLES}
+    for name, (opening, closing) in MARKUP_WRAPPERS.items():
+        result[name] = template.replace(WRAPPER_OPEN, opening).replace(WRAPPER_CLOSE, closing)
+    return result
+
+
+def running_text_position(pdf_bytes: bytes) -> str:
+    """Report where the running element's text ended up, if pymupdf is available."""
+    try:
+        import pymupdf
+    except ImportError:
+        return ""
+    with pymupdf.open(stream=pdf_bytes, filetype="pdf") as document:
+        for word in document[0].get_text("words"):
+            if "RUNNINGTEXT" in word[4]:
+                where = "top margin box" if word[1] < PAGE_MARGIN_PX else f"page body (y={word[1]:.1f})"
+                return f", running text in {where}"
+    return ", running text MISSING"
+
+
+label = f"{weasyprint.__version__}{'+patch' if patched else ''}"
+print(f"weasyprint {label}")
+for name, html in documents().items():
+    try:
+        pdf_bytes = weasyprint.HTML(string=html).write_pdf()
+    except Exception as error:  # noqa: BLE001
+        print(f"  {name:32} ->  CRASHES: {type(error).__name__}: {error}")
+    else:
+        print(f"  {name:32} ->  CONVERTS ok ({len(pdf_bytes)} bytes{running_text_position(pdf_bytes)})")

--- a/repro/repro_running_element.py
+++ b/repro/repro_running_element.py
@@ -94,7 +94,9 @@ print(f"weasyprint {label}")
 for name, html in documents().items():
     try:
         pdf_bytes = weasyprint.HTML(string=html).write_pdf()
-    except Exception as error:  # noqa: BLE001
+    except TypeError as error:
+        # Only the error under study is caught. Any other one is a new symptom and
+        # deserves its traceback rather than a line in this table.
         print(f"  {name:32} ->  CRASHES: {type(error).__name__}: {error}")
     else:
         print(f"  {name:32} ->  CONVERTS ok ({len(pdf_bytes)} bytes{running_text_position(pdf_bytes)})")

--- a/repro/run.sh
+++ b/repro/run.sh
@@ -2,6 +2,8 @@
 #
 # Native repro — runs straight on the host (no weasyprint-service, no Docker).
 #
+# Runs both reproductions in this directory. See README.md.
+#
 # Prerequisites:
 #   * uv                      (https://docs.astral.sh/uv/)
 #   * WeasyPrint system libs  — macOS:  brew install pango
@@ -18,9 +20,16 @@ if command -v brew >/dev/null 2>&1; then
   export DYLD_FALLBACK_LIBRARY_PATH="$(brew --prefix)/lib${DYLD_FALLBACK_LIBRARY_PATH:+:$DYLD_FALLBACK_LIBRARY_PATH}"
 fi
 
+echo "== PDF/A gradients =="
 for v in 68.1 69.0; do
   uv run --quiet --with "weasyprint==$v" --with pymupdf repro.py
 done
-
 # Same broken version, but with the weasyprint-service fix applied:
 uv run --quiet --with "weasyprint==69.0" --with pymupdf repro.py --patch
+
+echo
+echo "== Running element in a shrink-to-fit box =="
+for v in 68.1 69.0; do
+  uv run --quiet --with "weasyprint==$v" --with pymupdf repro_running_element.py
+done
+uv run --quiet --with "weasyprint==69.0" --with pymupdf repro_running_element.py --patch

--- a/repro/running_element.html
+++ b/repro/running_element.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html>
+  <head>
+    <style>
+      @page {
+        size: 400px 300px;
+        margin: 40px;
+        @top-center { content: element(header); }
+      }
+    </style>
+  </head>
+  <body>
+    <!--
+      The shrink-to-fit wrapper is what triggers the crash. repro_running_element.py
+      swaps `float: left` here for every other intrinsic-width wrapper it tests.
+      The @top-center rule above is not needed to reproduce it; it is here to check
+      that the running element still reaches its margin box once the fix is applied.
+    -->
+    <div style="float: left">
+      <div style="position: running(header)">RUNNINGTEXT</div>
+      WRAPPERTEXT
+    </div>
+    BODYTEXT
+  </body>
+</html>

--- a/tests/test_weasyprint_running_width_patch.py
+++ b/tests/test_weasyprint_running_width_patch.py
@@ -27,14 +27,28 @@ SHRINK_TO_FIT_WRAPPERS = {
 
 # The margin box that consumes the running element is not needed to trigger the crash,
 # so the wrapper cases above leave it out. This page has it, to check the patch does not
-# cost the running element its content.
-MARGIN_BOX_HTML = f'<!doctype html><html><head><style>@page{{size:400px 300px;margin:40px;@top-center{{content:element(header)}}}}</style></head><body><div style="float:left">{RUNNING_ELEMENT}WRAPPERTEXT</div>BODYTEXT</body></html>'
+# cost the running element its content. The running text is a parameter, because its
+# length is what tells a working @top-center from a collapsed one.
+MARGIN_BOX_TEMPLATE = (
+    "<!doctype html><html><head><style>@page{{size:400px 300px;margin:40px;@top-center{{content:element(header)}}}}</style></head>"
+    '<body><div style="float:left"><div style="position:running(header)">{running}</div>WRAPPERTEXT</div>BODYTEXT</body></html>'
+)
+
+PAGE_MARGIN_PX = 40
 
 
-def _page_words(pdf_bytes: bytes) -> list[tuple[float, float, str]]:
-    """Return the first page's words as (x, y, text), in reading order."""
+def _page_words(pdf_bytes: bytes) -> list[tuple[float, float, float, str]]:
+    """Return the first page's words as (left, top, right, text), in reading order."""
     with pymupdf.open(stream=pdf_bytes, filetype="pdf") as document:
-        return [(word[0], word[1], word[4]) for word in document[0].get_text("words")]
+        return [(word[0], word[1], word[2], word[4]) for word in document[0].get_text("words")]
+
+
+def _word(words, needle):
+    """Return the first word containing ``needle``, or fail with the whole page."""
+    for word in words:
+        if needle in word[3]:
+            return word
+    raise AssertionError(f"{needle} is missing from the page: {words}")
 
 
 @pytest.mark.parametrize("wrapper", SHRINK_TO_FIT_WRAPPERS.values(), ids=list(SHRINK_TO_FIT_WRAPPERS))
@@ -42,25 +56,47 @@ def test_running_element_in_shrink_to_fit_box_converts(wrapper):
     # Each of these raised TypeError before the patch, which the service reported as a 500.
     pdf_bytes = weasyprint.HTML(string=f"<!doctype html><html><body>{wrapper}</body></html>").write_pdf()
     assert pdf_bytes
-    assert any("WRAPPERTEXT" in text for _, _, text in _page_words(pdf_bytes))
+    assert _word(_page_words(pdf_bytes), "WRAPPERTEXT")
+
+
+def _margin_box_running_word(running_text):
+    """Render the margin-box page and return its running word, as (left, top, right)."""
+    words = _page_words(weasyprint.HTML(string=MARGIN_BOX_TEMPLATE.format(running=running_text)).write_pdf())
+    return _word(words, running_text[:11]), _word(words, "BODYTEXT")
 
 
 def test_running_element_still_reaches_its_margin_box():
     # The patch removes the running element from the intrinsic-width calculation only.
     # Its content must still be moved into the page margin box, above the body content.
-    words = _page_words(weasyprint.HTML(string=MARGIN_BOX_HTML).write_pdf())
-    running = [(x, y) for x, y, text in words if "RUNNINGTEXT" in text]
-    body = [(x, y) for x, y, text in words if "BODYTEXT" in text]
-    assert running, f"running element content is missing from the page: {words}"
-    assert body, f"body content is missing from the page: {words}"
-    assert running[0][1] < 40, "running element content is not in the top margin box"
-    assert running[0][1] < body[0][1]
+    running, body = _margin_box_running_word("RUNNINGTEXT")
+    assert running[1] < PAGE_MARGIN_PX, f"running element content is not in the top margin box: {running}"
+    assert running[1] < body[1]
+
+
+def test_margin_box_keeps_its_width():
+    # @top-center sizes itself from the running content's own intrinsic width, which is
+    # exactly what this patch returns zero for, so a collapsed margin box is the
+    # regression to catch. A centred box keeps the text centred on the same point
+    # whatever its length; a zero-width box anchors the text at that point and lets it
+    # overflow to the right, which moves the centre as the text grows. Comparing two
+    # lengths tests that without hard-coding a position WeasyPrint is free to change.
+    short, _ = _margin_box_running_word("RUNNINGTEXT")
+    long, _ = _margin_box_running_word("RUNNINGTEXTRUNNINGTEXTRUNNING")
+    assert long[2] - long[0] > short[2] - short[0], "the two runs must differ in width for this test to mean anything"
+    short_centre = (short[0] + short[2]) / 2
+    long_centre = (long[0] + long[2]) / 2
+    assert abs(short_centre - long_centre) < 1, f"the margin box collapsed: centres {short_centre} and {long_centre}"
 
 
 def test_document_without_running_elements_is_unaffected():
-    # The wrappers must stay shrink-to-fit: a float around plain text keeps its width.
-    html = '<!doctype html><html><body><div style="float:left">WRAPPERTEXT</div></body></html>'
-    assert any("WRAPPERTEXT" in text for _, _, text in _page_words(weasyprint.HTML(string=html).write_pdf()))
+    # A float around plain text must keep its width: the following text has to start at
+    # the float's right edge, not back at the page margin. The 20px margin on the float
+    # is what keeps the two runs far enough apart to be read as separate words.
+    html = '<!doctype html><html><body><div style="float:left;margin-right:20px">WRAPPERTEXT</div><p>BODYTEXT</p></body></html>'
+    words = _page_words(weasyprint.HTML(string=html).write_pdf())
+    wrapper = _word(words, "WRAPPERTEXT")
+    body = _word(words, "BODYTEXT")
+    assert body[0] >= wrapper[2], f"the float did not displace the text after it: {words}"
 
 
 def test_patch_is_installed():
@@ -72,6 +108,19 @@ def test_patch_is_installed():
 def test_patch_is_idempotent():
     # Already applied above, so a further call must be a no-op.
     assert apply_running_width_patch() is False
+
+
+def test_layout_module_import_failure_returns_none():
+    # The private WeasyPrint layout modules are imported through this helper so a
+    # future rename cannot stop the service from starting.
+    assert weasyprint_running_width_patch._layout_module("no_such_layout_module") is None
+
+
+def test_apply_skips_when_the_layout_module_is_missing(monkeypatch):
+    # Same, from the caller's side: no weasyprint.layout.preferred means a no-op.
+    monkeypatch.setattr(weasyprint_running_width_patch, "weasyprint_preferred", None)
+    assert apply_running_width_patch() is False
+    assert is_applied() is False
 
 
 def test_apply_skips_when_intrinsic_width_functions_missing(monkeypatch):

--- a/tests/test_weasyprint_running_width_patch.py
+++ b/tests/test_weasyprint_running_width_patch.py
@@ -1,0 +1,91 @@
+"""Regression test for the WeasyPrint running-element intrinsic-width patch."""
+
+import pymupdf
+import pytest
+import weasyprint
+
+from app import weasyprint_running_width_patch
+from app.weasyprint_running_width_patch import apply_running_width_patch, is_applied
+
+# Apply the same fix the service applies at import of weasyprint_controller.
+apply_running_width_patch()
+
+# A block-level running element holding text. Without the patch, every intrinsic-width
+# (shrink-to-fit) wrapper below makes WeasyPrint recurse into it, reach the bare TextBox
+# that inline_in_block never wrapped in a line box, and raise
+# TypeError: min-content width for TextBox not handled yet.
+RUNNING_ELEMENT = '<div style="position:running(header)">RUNNINGTEXT</div>'
+
+SHRINK_TO_FIT_WRAPPERS = {
+    "float": f'<div style="float:left">{RUNNING_ELEMENT}WRAPPERTEXT</div>',
+    "inline-block": f'<div style="display:inline-block">{RUNNING_ELEMENT}WRAPPERTEXT</div>',
+    "absolute": f'<div style="position:absolute">{RUNNING_ELEMENT}WRAPPERTEXT</div>',
+    "table-cell": f"<table><tr><td>{RUNNING_ELEMENT}WRAPPERTEXT</td></tr></table>",
+    "flex-item": f'<div style="display:flex;width:min-content"><div>{RUNNING_ELEMENT}WRAPPERTEXT</div></div>',
+    "nested-float": f'<div style="float:left"><div><section>{RUNNING_ELEMENT}</section></div>WRAPPERTEXT</div>',
+}
+
+# The margin box that consumes the running element is not needed to trigger the crash,
+# so the wrapper cases above leave it out. This page has it, to check the patch does not
+# cost the running element its content.
+MARGIN_BOX_HTML = f'<!doctype html><html><head><style>@page{{size:400px 300px;margin:40px;@top-center{{content:element(header)}}}}</style></head><body><div style="float:left">{RUNNING_ELEMENT}WRAPPERTEXT</div>BODYTEXT</body></html>'
+
+
+def _page_words(pdf_bytes: bytes) -> list[tuple[float, float, str]]:
+    """Return the first page's words as (x, y, text), in reading order."""
+    with pymupdf.open(stream=pdf_bytes, filetype="pdf") as document:
+        return [(word[0], word[1], word[4]) for word in document[0].get_text("words")]
+
+
+@pytest.mark.parametrize("wrapper", SHRINK_TO_FIT_WRAPPERS.values(), ids=list(SHRINK_TO_FIT_WRAPPERS))
+def test_running_element_in_shrink_to_fit_box_converts(wrapper):
+    # Each of these raised TypeError before the patch, which the service reported as a 500.
+    pdf_bytes = weasyprint.HTML(string=f"<!doctype html><html><body>{wrapper}</body></html>").write_pdf()
+    assert pdf_bytes
+    assert any("WRAPPERTEXT" in text for _, _, text in _page_words(pdf_bytes))
+
+
+def test_running_element_still_reaches_its_margin_box():
+    # The patch removes the running element from the intrinsic-width calculation only.
+    # Its content must still be moved into the page margin box, above the body content.
+    words = _page_words(weasyprint.HTML(string=MARGIN_BOX_HTML).write_pdf())
+    running = [(x, y) for x, y, text in words if "RUNNINGTEXT" in text]
+    body = [(x, y) for x, y, text in words if "BODYTEXT" in text]
+    assert running, f"running element content is missing from the page: {words}"
+    assert body, f"body content is missing from the page: {words}"
+    assert running[0][1] < 40, "running element content is not in the top margin box"
+    assert running[0][1] < body[0][1]
+
+
+def test_document_without_running_elements_is_unaffected():
+    # The wrappers must stay shrink-to-fit: a float around plain text keeps its width.
+    html = '<!doctype html><html><body><div style="float:left">WRAPPERTEXT</div></body></html>'
+    assert any("WRAPPERTEXT" in text for _, _, text in _page_words(weasyprint.HTML(string=html).write_pdf()))
+
+
+def test_patch_is_installed():
+    # Without this, the render tests above would pass silently on a WeasyPrint version
+    # whose internals moved, masking a fix that was never installed.
+    assert is_applied() is True
+
+
+def test_patch_is_idempotent():
+    # Already applied above, so a further call must be a no-op.
+    assert apply_running_width_patch() is False
+
+
+def test_apply_skips_when_intrinsic_width_functions_missing(monkeypatch):
+    # A future WeasyPrint without these functions must fail safe, not raise at import.
+    monkeypatch.delattr(weasyprint_running_width_patch.weasyprint_preferred, "table_cell_min_content_width")
+    assert apply_running_width_patch() is False
+    assert is_applied() is False
+
+
+def test_patch_survives_a_box_without_is_running(monkeypatch):
+    # An unexpected box type must not break PDF generation.
+    class BoxWithoutIsRunning:
+        def is_running(self):
+            raise AttributeError("no is_running")
+
+    wrapped = weasyprint_running_width_patch._zero_for_running(lambda context, box: 42, 0)
+    assert wrapped(None, BoxWithoutIsRunning()) == 42


### PR DESCRIPTION
### Proposed changes

A PDF conversion fails with HTTP 500 and `TypeError: min-content width for TextBox not handled yet`, reported from a pdf-exporter cover page. Three ingredients are needed, and removing any one makes the error disappear:

1. `position: running(name)` on a **block-level** element.
2. **Text** inside it. An empty running element is fine, and so is `position: running()` on an inline `<span>`.
3. An **intrinsic-width (shrink-to-fit) wrapper** around it: `float`, `display: inline-block`, `position: absolute`, an auto-layout `<td>`, or a flex item.

Minimal input:

```html
<!doctype html><html><body><div style="float:left"><div style="position:running(r)">x</div></div></body></html>
```

The `@page { @top-center { content: element(r) } }` rule that normally consumes the running element is **not** required, and `width: min-content` on the wrapper does not trigger it either. Reproduced on WeasyPrint 68.1 and 69.0. No upstream issue exists for it yet.

Two WeasyPrint details combine into the crash. `formatting_structure/build.py` returns early from `inline_in_block()` for a running box, so its text is never wrapped in a `LineBox` and a bare `TextBox` survives as a direct child of the block. `layout/preferred.py` then filters only absolutely positioned children out of the intrinsic-width walk, recurses into the running box, reaches that `TextBox` and has no branch for it.

A running element is removed from the normal flow, as `Box.is_in_normal_flow()` states, so it must not contribute to its container's intrinsic width at all. `app/weasyprint_running_width_patch.py` returns zero for a running box at every entry point of that calculation: `min_content_width`, `max_content_width`, `table_cell_min_content_width` and `table_cell_min_max_content_width`. It also mirrors the first two onto `layout/flex.py`, `layout/grid.py` and `layout/page.py`, which bind them by name at import and would otherwise keep unpatched copies. The patch follows `app/weasyprint_pdfa_patch.py`: applied at import of the controller, idempotent, and a no-op if a future WeasyPrint moves these internals, so it can never break PDF generation.

The running content still reaches its page margin box. The patch only removes it from a width calculation it was never meant to take part in.

Two exotic cases stay broken, with a different error (`TypeError: Layout for TextBox not handled yet`), because table and grid layout keep a running child in the flow: a `<td>` that is itself the running element, and a running element that is itself a grid item. Neither produces the error this PR is about, and both were already broken. `repro/README.md` records them.

### Tests

- `tests/test_weasyprint_running_width_patch.py`: all six shrink-to-fit wrappers convert (each verified to raise against the old code), the running content still lands in the `@top-center` margin box above the body content, a document without running elements is unchanged, plus the patch being installed, idempotent, and failing safe when the WeasyPrint internals are missing.
- `repro/repro_running_element.py` and `repro/running_element.html`: a service-free reproduction that runs the same patch, so the next WeasyPrint bump can be checked before the workaround is kept or dropped. `repro/run.sh` now runs it alongside the PDF/A gradient repro, and `repro/README.md` became an index of the two.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
